### PR TITLE
mom-40 Remove use of uninitialised variables

### DIFF
--- a/src/mom5/ocean_core/ocean_grids.F90
+++ b/src/mom5/ocean_core/ocean_grids.F90
@@ -283,8 +283,7 @@ subroutine set_ocean_grid_size(Grid, grid_file, grid_name)
      call read_data(ocean_mosaic, "gridfiles", ocean_hgrid)
      ocean_hgrid = 'INPUT/'//trim(ocean_hgrid)
      call field_size(ocean_hgrid, 'x', siz)
-     Grid%ni = nx(1)
-     Grid%nj = ny(1)
+     
      if(mod(siz(1),2) .NE. 1) call mpp_error(FATAL, '==>Error from ocean_grids_mod(set_ocean_grid_size): '//&
           'x-size of x in file '//trim(ocean_hgrid)//' should be 2*ni+1')
      if(mod(siz(2),2) .NE. 1) call mpp_error(FATAL, '==>Error from ocean_grids_mod(set_ocean_grid_size): '//&


### PR DESCRIPTION
Remove line 286 and 287 to avoid possible un-initialized issue.
 Grid%ni = nx(1)  --- line 286
 Grid%nj = ny(1)  --- line 287
