### PR TITLE
Added command line option check to mppnccombine

### DIFF
--- a/src/postprocessing/mppnccombine/mppnccombine.c
+++ b/src/postprocessing/mppnccombine/mppnccombine.c
@@ -331,6 +331,11 @@ int main(int argc, char *argv[])
 	 compress=1;
         }
       else if (!strcmp(argv[a],"-s")) shuffle=0;
+      else if (argv[a][0] == '-')
+	{
+	  printf("Illegal option %s\n\n", argv[a]);
+	  usage(); return(1);
+	}
       else
         {
          outputarg=a; break;


### PR DESCRIPTION
The program for collating tiled MOM outputs (mppnccombine) silently ignored bad command line options without producing an error condition.

Addresses this issue: https://github.com/mom-ocean/MOM5/issues/180

This change checks for a command line argument that has fallen through all the other checks and if begins with '-' it flags an error.

Lightly tested but not in production.