### PR TITLE
Heat budget diagnostic binned to temperature layers

### DIFF
--- a/src/mom5/ocean_core/ocean_density.F90
+++ b/src/mom5/ocean_core/ocean_density.F90
@@ -2622,19 +2622,19 @@ end subroutine update_ocean_density
       '==>Error in ocean_density_mod (neutral_density_field): module must be initialized')
     endif 
 
-    if(eos_linear) then
-        do k=1,nk
-           do j=jsd,jed
-              do i=isd,ied
-                 neutral_density_field(i,j,k) = rho0 - alpha_linear_eos*theta(i,j,k) + beta_linear_eos*salinity(i,j,k)
-              enddo
-           enddo
-        enddo
-    elseif(neutral_rho_equal_theta) then
+    if(neutral_rho_equal_theta) then
         do k=1,nk
            do j=jsd,jed
               do i=isd,ied
                  neutral_density_field(i,j,k) = theta(i,j,k)
+              enddo
+           enddo
+        enddo
+    elseif(eos_linear) then
+        do k=1,nk
+           do j=jsd,jed
+              do i=isd,ied
+                 neutral_density_field(i,j,k) = rho0 - alpha_linear_eos*theta(i,j,k) + beta_linear_eos*salinity(i,j,k)
               enddo
            enddo
         enddo
@@ -2672,13 +2672,13 @@ end subroutine update_ocean_density
       '==>Error in ocean_density_mod (neutral_density_point): module must be initialized')
     endif 
 
-    if(eos_linear) then
-
-        neutral_density_point = rho0 - alpha_linear_eos*theta + beta_linear_eos*salinity
-
-    elseif(neutral_rho_equal_theta) then
+    if(neutral_rho_equal_theta) then
 
         neutral_density_point = theta
+
+    elseif(eos_linear) then
+
+        neutral_density_point = rho0 - alpha_linear_eos*theta + beta_linear_eos*salinity
 
     else
 

--- a/src/mom5/ocean_core/ocean_density.F90
+++ b/src/mom5/ocean_core/ocean_density.F90
@@ -218,7 +218,12 @@ module ocean_density_mod
 !  and temperature. 
 !  Default eos_linear=.false.
 !  </DATA>
-!
+!  <DATA NAME="neutral_rho_equal_theta" TYPE="logical">
+!  Set to true to use temperature instead of neutral density as the
+!  binning variable for water-mass diagnostics.
+!  Default neutral_rho_equal_theta=.false.
+!  </DATA>
+
 !  <DATA NAME="alpha_linear_eos" TYPE="real">
 !  Constant "thermal expansion coefficient" for linear EOS 
 !  rho = rho0 - alpha_linear_eos*theta + beta_linear_eos*salinity
@@ -611,6 +616,9 @@ logical :: eos_linear=.false.
 real    :: alpha_linear_eos=0.255
 real    :: beta_linear_eos =0.0
 
+! for water-mass transformation theta
+logical :: neutral_rho_equal_theta = .false.
+
 ! for teos10 or preteos10 eos
 logical :: eos_preteos10 = .false.
 logical :: eos_teos10    = .false.
@@ -700,6 +708,7 @@ logical :: do_bitwise_exact_sum  = .false.
 namelist /ocean_density_nml/ s_test, t_test, p_test, press_standard,                  &
                              sn_test, tn_test,                                        &
                              eos_linear, alpha_linear_eos, beta_linear_eos,           & 
+                             neutral_rho_equal_theta,                                 &
                              eos_preteos10, eos_teos10,                               &
                              potrho_press, potrho_min, potrho_max,                    &
                              neutralrho_min, neutralrho_max,                          &
@@ -2604,6 +2613,14 @@ end subroutine update_ocean_density
               enddo
            enddo
         enddo
+    elseif(neutral_rho_equal_theta) then
+        do k=1,nk
+           do j=jsd,jed
+              do i=isd,ied
+                 neutral_density_field(i,j,k) = theta(i,j,k)
+              enddo
+           enddo
+        enddo
     else
          neutral_density_field = potential_density(salinity,theta,potrho_press)
     endif 
@@ -2641,6 +2658,10 @@ end subroutine update_ocean_density
     if(eos_linear) then
 
         neutral_density_point = rho0 - alpha_linear_eos*theta + beta_linear_eos*salinity
+
+    elseif(neutral_rho_equal_theta) then
+
+        neutral_density_point = theta
 
     else
 

--- a/src/mom5/ocean_core/ocean_model.F90
+++ b/src/mom5/ocean_core/ocean_model.F90
@@ -1267,7 +1267,7 @@ subroutine ocean_model_init(Ocean, Ocean_state, Time_init, Time_in)
     call calculate_rhoT(Time, Dens, Thickness)
 
     ! initialize diagnostics inside ocean_tracer module, which require density to already be initialized 
-    call ocean_tracer_diagnostics_init(Time, Dens, T_diag, vert_coordinate_class)  
+    call ocean_tracer_diagnostics_init(Time, Dens, T_diag, T_prog, vert_coordinate_class)
 
     call ocean_thickness_init_adjust(Grid, Time, Dens, Ext_mode, Thickness)
 

--- a/src/mom5/ocean_core/ocean_sbc.F90
+++ b/src/mom5/ocean_core/ocean_sbc.F90
@@ -514,6 +514,7 @@ integer, allocatable, dimension(:) :: id_stf_total
 integer, allocatable, dimension(:) :: id_stf_runoff
 integer, allocatable, dimension(:) :: id_stf_calving
 integer, allocatable, dimension(:) :: id_stf_pme
+integer, allocatable, dimension(:) :: id_stf_pme_on_nrho
 integer, allocatable, dimension(:) :: id_stf_prec
 integer, allocatable, dimension(:) :: id_stf_evap
 integer, allocatable, dimension(:) :: id_trunoff
@@ -1512,6 +1513,7 @@ subroutine ocean_sbc_diag_init(Time, Dens, T_prog)
   allocate( id_stf_runoff            (num_prog_tracers) )
   allocate( id_stf_calving           (num_prog_tracers) )
   allocate( id_stf_pme               (num_prog_tracers) )
+  allocate( id_stf_pme_on_nrho       (num_prog_tracers) )
   allocate( id_stf_prec              (num_prog_tracers) )
   allocate( id_stf_evap              (num_prog_tracers) )
   allocate( id_trunoff               (num_prog_tracers) )
@@ -1535,6 +1537,7 @@ subroutine ocean_sbc_diag_init(Time, Dens, T_prog)
   id_stf_runoff            (:)  = -1
   id_stf_calving           (:)  = -1
   id_stf_pme               (:)  = -1
+  id_stf_pme_on_nrho       (:)  = -1
   id_stf_prec              (:)  = -1
   id_stf_evap              (:)  = -1
   id_trunoff               (:)  = -1
@@ -2187,6 +2190,10 @@ subroutine ocean_sbc_diag_init(Time, Dens, T_prog)
               Grd%tracer_axes(1:2),                                                                          &
               Time%model_time, 'heat flux (relative to 0C) from pme transfer of water across ocean surface', &
               'Watts/m^2' , missing_value=missing_value,range=(/-1.e4,1.e4/))            
+         id_stf_pme_on_nrho(n) = register_diag_field('ocean_model','sfc_hflux_pme_on_nrho',                                  &
+              Dens%neutralrho_axes(1:3),                                                                      &
+              Time%model_time, 'heat flux (relative to 0C) from pme transfer of water across ocean surface binned to neutral density', &
+              'Watts/m^2' , missing_value=missing_value,range=(/-1.e20,1.e20/))
          id_stf_prec(n) = register_diag_field('ocean_model','sfc_hflux_from_water_prec',      &
               Grd%tracer_axes(1:2),                                                           &
               Time%model_time, 'heat flux from precip transfer of water across ocean surface',&
@@ -2301,6 +2308,13 @@ subroutine ocean_sbc_diag_init(Time, Dens, T_prog)
               Time%model_time, trim(name),                 &
               'kg/(m^2*sec)' ,                             &
               missing_value=missing_value,range=(/-1.e4,1.e4/))            
+         name = 'sfc_'//trim(T_prog(n)%name)//'_flux_pme_on_nrho'
+         id_stf_pme_on_nrho(n) = register_diag_field('ocean_model',&
+              trim(name),                                  &
+              Dens%neutralrho_axes(1:3),                    &
+              Time%model_time, trim(name),                 &
+              'kg/(m^2*sec)' ,                             &
+              missing_value=missing_value,range=(/-1.e20,1.e20/))
          name = 'sfc_'//trim(T_prog(n)%name)//'_flux_prec'
          id_stf_prec(n) = register_diag_field('ocean_model',&
               trim(name),                                   & 
@@ -2428,6 +2442,13 @@ subroutine ocean_sbc_diag_init(Time, Dens, T_prog)
               Time%model_time, trim(name),                 &
               'kg/(m^2*sec)' ,                             &
               missing_value=missing_value,range=(/-1.e4,1.e4/))            
+         name = 'sfc_'//trim(T_prog(n)%name)//'_flux_pme_on_nrho'
+         id_stf_pme_on_nrho(n) = register_diag_field('ocean_model',&
+              trim(name),                                  &
+              Dens%neutralrho_axes(1:3),                    &
+              Time%model_time, trim(name),                 &
+              'kg/(m^2*sec)' ,                             &
+              missing_value=missing_value,range=(/-1.e20,1.e20/))
          name = 'sfc_'//trim(T_prog(n)%name)//'_flux_prec'
          id_stf_prec(n) = register_diag_field('ocean_model',&
               trim(name),                                   &
@@ -4245,6 +4266,18 @@ subroutine flux_adjust(Time, T_diag, Dens, Ext_mode, T_prog, Velocity, river, me
   if (id_stf_pme(index_temp) > 0) then
      call diagnose_2d(Time, Grd, id_stf_pme(index_temp),       &
              pme(:,:)*T_prog(index_temp)%tpme(:,:)*T_prog(index_temp)%conversion)
+  endif
+  ! heat input from net pme relative to 0 degrees C (W/m2) binned to
+  ! neutral density
+  if (id_stf_pme_on_nrho(index_temp) > 0) then
+      wrk1(:,:,:)      = 0.0
+      k=1
+      do j=jsc,jec
+         do i=isc,iec
+            wrk1(i,j,k) = pme(i,j)*T_prog(index_temp)%tpme(i,j)*T_prog(index_temp)%conversion
+         enddo
+      enddo
+      call diagnose_3d_rho(Time, Dens, id_stf_pme_on_nrho(index_temp), wrk1)
   endif
   ! total heat flux from net pme (Watts)
   if(id_total_ocean_stf_pme(index_temp) > 0) then 

--- a/src/mom5/ocean_param/sources/ocean_shortwave.F90
+++ b/src/mom5/ocean_param/sources/ocean_shortwave.F90
@@ -76,6 +76,7 @@ real    :: cellarea_r
 ! for diagnostics 
 integer :: id_sw_frac       =-1
 integer :: id_sw_heat       =-1
+integer :: id_sw_heat_on_nrho=-1
 integer :: id_irradiance    =-1
 
 integer :: id_neut_rho_sw          =-1
@@ -385,7 +386,12 @@ subroutine watermass_diag_init(Time, Dens)
   integer :: stdoutunit
   stdoutunit=stdout()
   compute_watermass_diag = .false. 
-  
+
+  id_sw_heat_on_nrho = register_diag_field ('ocean_model', 'sw_heat_on_nrho',   &
+       Dens%neutralrho_axes(1:3), Time%model_time, 'penetrative shortwave heating binned to neutral density', &
+       'W/m^2', missing_value=-1e10, range=(/-1.e20,1.e20/))
+  if(id_sw_heat_on_nrho > 0) compute_watermass_diag = .true.
+
   id_neut_rho_sw = register_diag_field ('ocean_model', 'neut_rho_sw',&
     Grd%tracer_axes(1:3), Time%model_time,                           &
     'update of locally ref potrho from shortwave penetration',       &
@@ -495,6 +501,7 @@ subroutine watermass_diag(Time, Temp, Dens)
   call diagnose_3d_rho(Time, Dens, id_neut_rho_sw_on_nrho, wrk2)
   call diagnose_3d_rho(Time, Dens, id_wdian_rho_sw_on_nrho, wrk3)
   call diagnose_3d_rho(Time, Dens, id_tform_rho_sw_on_nrho, wrk4)
+  call diagnose_3d_rho(Time, Dens, id_sw_heat_on_nrho, Temp%wrk1)
 
   if(id_eta_tend_sw_pen > 0 .or. id_eta_tend_sw_pen_glob > 0) then
       eta_tend(:,:) = 0.0

--- a/src/mom5/ocean_param/vertical/ocean_vert_kpp_mom4p1.F90
+++ b/src/mom5/ocean_param/vertical/ocean_vert_kpp_mom4p1.F90
@@ -431,6 +431,7 @@ logical :: compute_watermass_diag = .false.
 
 ! for diagnostics 
 integer, dimension(:), allocatable :: id_nonlocal(:)
+integer, dimension(:), allocatable :: id_nonlocal_on_nrho(:)
 integer, dimension(:), allocatable :: id_ghats(:)
 integer, dimension(:), allocatable :: id_wsfc(:)
 integer, dimension(:), allocatable :: id_wbot(:)
@@ -846,16 +847,22 @@ ierr = check_nml_error(io_status,'ocean_vert_kpp_mom4p1_nml')
   ! register diagnostics 
 
   allocate(id_nonlocal(num_prog_tracers))
+  allocate(id_nonlocal_on_nrho(num_prog_tracers))
   allocate(id_ghats(2))
   allocate(id_wsfc(num_prog_tracers))
   allocate(id_wbot(num_prog_tracers))
   id_nonlocal=-1
+  id_nonlocal_on_nrho=-1
   do n = 1, num_prog_tracers
      if(n==index_temp) then
         id_nonlocal(n) = register_diag_field ('ocean_model', trim(T_prog(n)%name)//'_nonlocal_KPP', &
                      Grd%tracer_axes(1:3), Time%model_time,                                         &
                      'cp*rho*dzt*nonlocal tendency from KPP', trim(T_prog(n)%flux_units),           &
                      missing_value=missing_value, range=(/-1.e10,1.e10/))
+        id_nonlocal_on_nrho(n) = register_diag_field ('ocean_model', trim(T_prog(n)%name)//'_nonlocal_KPP_on_nrho', &
+                     Dens%neutralrho_axes(1:3), Time%model_time,                                         &
+                     'cp*rho*dzt*nonlocal tendency from KPP binned to neutral density', trim(T_prog(n)%flux_units), &
+                     missing_value=missing_value, range=(/-1.e20,1.e20/))
         id_wsfc(n)   = register_diag_field ('ocean_model', trim(T_prog(n)%name)//'_wsfc_KPP',       &
                      Grd%tracer_axes(1:2), Time%model_time,                                         &
                      'cp*rho*dzt*surface tendency from KPP', trim(T_prog(n)%flux_units),            &
@@ -865,6 +872,10 @@ ierr = check_nml_error(io_status,'ocean_vert_kpp_mom4p1_nml')
                      Grd%tracer_axes(1:3), Time%model_time,                                         &
                      'rho*dzt*nonlocal tendency from KPP', trim(T_prog(n)%flux_units),              &
                      missing_value=missing_value, range=(/-1.e10,1.e10/))
+        id_nonlocal_on_nrho(n) = register_diag_field ('ocean_model', trim(T_prog(n)%name)//'_nonlocal_KPP_on_nrho', &
+                     Dens%neutralrho_axes(1:3), Time%model_time,                                         &
+                     'rho*dzt*nonlocal tendency from KPP binned to neutral density', trim(T_prog(n)%flux_units),              &
+                     missing_value=missing_value, range=(/-1.e20,1.e20/))
         id_wsfc(n)   =  register_diag_field ('ocean_model', trim(T_prog(n)%name)//'_wsfc_KPP',      &
                      Grd%tracer_axes(1:2), Time%model_time,                                         &
                      'rho*dzt*surface tendency from KPP', trim(T_prog(n)%flux_units),               &
@@ -1500,6 +1511,9 @@ subroutine vert_mix_kpp_mom4p1 (aidif, Time, Thickness, Velocity, T_prog, T_diag
 
               if (id_nonlocal(n) > 0) then 
                  call diagnose_3d(Time, Grd, id_nonlocal(n),T_prog(n)%conversion*T_prog(n)%wrk1(:,:,:))
+              endif
+              if (id_nonlocal_on_nrho(n) > 0) then
+                 call diagnose_3d_rho(Time, Dens, id_nonlocal_on_nrho(n),T_prog(n)%conversion*T_prog(n)%wrk1)
               endif
 
            enddo   ! enddo for n-loop 


### PR DESCRIPTION
This pull request adds a number of diagnostics that output the terms in the heat budget binned to temperature layers using the binning routine diagnose_3d_rho. I have used these in a recent study of heat transport in temperature space in MOM025-SIS and MOM01-SIS. I am adding them here as they could be potentially useful for A. Hogg and K. Stewart in diagnosing implicit mixing in 1-deg runs with varying vertical resolution.

@aidanheerdegen or @nicjhan - can you check these please? I've tested them with Paul's MOM025-SIS, and MOM01-SIS configurations. Let me know if there are any issues.