### PR TITLE
Add explicit stack trace for intel compiler from PE that issues FATAL

### DIFF
--- a/src/mom5/ocean_core/ocean_sbc.F90
+++ b/src/mom5/ocean_core/ocean_sbc.F90
@@ -337,6 +337,14 @@ module ocean_sbc_mod
 !  as that is the value used in the GFDL coupled climate model. 
 !  </DATA> 
 !
+!  <DATA NAME="ocean_ice_salt_limit" UNITS="kg salt / kg ice" TYPE="real">
+!  The minimum salt concentration of water forming sea ice.  This shouldbe at least that used by the ice model
+!  otherwise it is possible to extract more salt than physically exists.
+!  Default is ocean_ice_salt_limit=0.0 in order to reproduce older results.
+!  It is suggested that ocean_ice_salt_limit > ice_salt_concentration +  0.001 to prevent dropping below
+!  ice_salt_concentration by mistake.
+!  </DATA>
+!
 !  <DATA NAME="runoff_salinity" UNITS="g salt / kg runoff water (ppt)" TYPE="real">
 !  The salinity of river runoff water. Default is runoff_salinity=0.0.
 !  </DATA> 
@@ -831,6 +839,7 @@ real    :: constant_sss_for_restore       = 35.0
 real    :: constant_sst_for_restore       = 12.0
 real    :: sbc_heat_fluxes_const_value    = 0.0    ! W/m2
 real    :: ice_salt_concentration         = 0.005  ! kg/kg
+real    :: ocean_ice_salt_limit           = 0.0    ! kg/kg
 real    :: runoff_salinity                = 0.0    ! psu
 real    :: runoff_temp_min                = 0.0    ! degC
 real    :: temp_restore_tscale            = -30.
@@ -868,7 +877,7 @@ namelist /ocean_sbc_nml/ temp_restore_tscale, salt_restore_tscale, salt_restore_
          zero_net_salt_correction, zero_net_water_correction,                                                                &
          debug_water_fluxes, zero_water_fluxes, zero_calving_fluxes, zero_pme_fluxes, zero_runoff_fluxes, zero_river_fluxes, &
          convert_river_to_pme, zero_heat_fluxes, zero_surface_stress, avg_sfc_velocity, avg_sfc_temp_salt_eta,               &
-         ice_salt_concentration, runoff_salinity, runoff_temp_min, read_restore_mask, restore_mask_gfdl,                     &
+         ice_salt_concentration, ocean_ice_salt_limit, runoff_salinity, runoff_temp_min, read_restore_mask, restore_mask_gfdl,&
          land_model_heat_fluxes, use_full_patm_for_sea_level, max_delta_salinity_restore, do_flux_correction,                &
          salinity_restore_limit_lower, salinity_restore_limit_upper,                                                          &
          temp_correction_scale, salt_correction_scale, tau_x_correction_scale, tau_y_correction_scale, do_bitwise_exact_sum, &
@@ -4329,6 +4338,18 @@ subroutine flux_adjust(Time, T_diag, Dens, Ext_mode, T_prog, Velocity, river, me
                  enddo
               enddo
           endif
+
+          ! Restrict outgoing salt flux (ice being formed) in cases where salinity falls below
+          ! ocean_ice_salt_limit. If zero_net_salt_restore=.true. then the mismatch will be
+          ! spread globally by the following block of code.
+
+          do j=jsc,jec
+             do i=isc,iec
+                if (T_prog(index_salt)%stf(i,j) < 0.0 .and. T_prog(index_salt)%field(i,j,1,taum1) < ocean_ice_salt_limit * 1000.0) then
+                     flx_restore(i,j) = flx_restore(i,j) - T_prog(index_salt)%stf(i,j)
+                endif
+             enddo
+          enddo
 
           ! produce a zero area average so there is no net input
           ! of salt to the ocean associated with the restoring 

--- a/src/mom5/ocean_core/ocean_sbc.F90
+++ b/src/mom5/ocean_core/ocean_sbc.F90
@@ -4343,13 +4343,15 @@ subroutine flux_adjust(Time, T_diag, Dens, Ext_mode, T_prog, Velocity, river, me
           ! ocean_ice_salt_limit. If zero_net_salt_restore=.true. then the mismatch will be
           ! spread globally by the following block of code.
 
-          do j=jsc,jec
-             do i=isc,iec
-                if (T_prog(index_salt)%stf(i,j) < 0.0 .and. T_prog(index_salt)%field(i,j,1,taum1) < ocean_ice_salt_limit * 1000.0) then
-                     flx_restore(i,j) = flx_restore(i,j) - T_prog(index_salt)%stf(i,j)
-                endif
+          if( ocean_ice_salt_limit > 0.0 ) then
+             do j=jsc,jec
+                do i=isc,iec
+                   if (T_prog(index_salt)%stf(i,j) < 0.0 .and. T_prog(index_salt)%field(i,j,1,taum1) < ocean_ice_salt_limit * 1000.0) then
+                        flx_restore(i,j) = flx_restore(i,j) - T_prog(index_salt)%stf(i,j)
+                   endif
+                enddo
              enddo
-          enddo
+          endif
 
           ! produce a zero area average so there is no net input
           ! of salt to the ocean associated with the restoring 

--- a/src/shared/mpp/include/mpp_util_mpi.inc
+++ b/src/shared/mpp/include/mpp_util_mpi.inc
@@ -9,6 +9,10 @@
 
 subroutine mpp_error_basic( errortype, errormsg )
   !a very basic error handler
+#ifdef __INTEL_COMPILER
+  ! Needs special traceback module for intel compile RASF
+   use ifcore
+#endif
   !uses ABORT and FLUSH calls, may need to use cpp to rename
   integer,                    intent(in) :: errortype
   character(len=*), intent(in), optional :: errormsg
@@ -48,6 +52,10 @@ subroutine mpp_error_basic( errortype, errormsg )
         call FLUSH(out_unit)
 #ifdef sgi_mipspro
         call TRACE_BACK_STACK_AND_PRINT()
+#endif
+#ifdef __INTEL_COMPILER
+  ! Get traceback and return quietly for correct abort
+        call TRACEBACKQQ(user_exit_code=-1)
 #endif
         call MPI_ABORT( MPI_COMM_WORLD, 1, error )
      end if

--- a/src/shared/mpp/include/mpp_util_nocomm.inc
+++ b/src/shared/mpp/include/mpp_util_nocomm.inc
@@ -11,6 +11,10 @@
 subroutine mpp_error_basic( errortype, errormsg )
   !a very basic error handler
   !uses ABORT and FLUSH calls, may need to use cpp to rename
+#ifdef __INTEL_COMPILER
+  ! Needs special traceback module for intel compile RASF
+   use ifcore
+#endif
   integer,                    intent(in) :: errortype
   character(len=*), intent(in), optional :: errormsg
   character(len=512)                     :: text
@@ -46,6 +50,10 @@ subroutine mpp_error_basic( errortype, errormsg )
         call FLUSH(outunit)
 #ifdef sgi_mipspro
         call TRACE_BACK_STACK_AND_PRINT()
+#endif
+#ifdef __INTEL_COMPILER
+  ! Get traceback and return quietly for correct abort
+        call TRACEBACKQQ(user_exit_code=-1)
 #endif
         call ABORT() !automatically calls traceback on Cray systems
      end if


### PR DESCRIPTION
Ever had to wade through thousand of stack frames and possibly never find where the FATAL was issued from? This makes sure we get the offending PE's stack trace as the first one for the intel compiler series. Control is returned to the code for the normal cleanup. 