### PR TITLE
Load common modules via environs.access-om2.nci, plus a minor bug fix

### DIFF
--- a/bin/environs.nci
+++ b/bin/environs.nci
@@ -1,7 +1,13 @@
 source /etc/profile.d/nf_csh_modules
-module purge
-module load intel-fc/17.0.1.132
-module load intel-cc/17.0.1.132
-module load netcdf/4.2.1.1
-module load openmpi/1.10.2
+if ( -f ../../../modules.nci ) then
+    echo "Loading common modules via modules.nci"
+    source ../../../modules.nci
+else
+    echo "WARNING: modules.nci not found. Module versions might differ between model components."
+    module purge
+    module load intel-fc/17.0.1.132
+    module load intel-cc/17.0.1.132
+    module load netcdf/4.2.1.1
+    module load openmpi/1.10.2
+endif
 setenv mpirunCommand   "mpirun --mca orte_base_help_aggregate 0 -np"

--- a/bin/environs.nci
+++ b/bin/environs.nci
@@ -1,9 +1,9 @@
 source /etc/profile.d/nf_csh_modules
-if ( -f ../../../modules.nci ) then
-    echo "Loading common modules via modules.nci"
-    source ../../../modules.nci
+if ( -f ../../../environs.access-om2.nci ) then
+    echo "Loading common modules via environs.access-om2.nci"
+    source ../../../environs.access-om2.nci
 else
-    echo "WARNING: modules.nci not found. Module versions might differ between model components."
+    echo "WARNING: environs.access-om2.nci not found. Module versions might differ between model components."
     module purge
     module load intel-fc/17.0.1.132
     module load intel-cc/17.0.1.132

--- a/exp/MOM_compile.csh
+++ b/exp/MOM_compile.csh
@@ -1,7 +1,7 @@
 #!/bin/csh -f
 # Minimal compile script for fully coupled model CM2M experiments
 
-set platform      = gfortran    # A unique identifier for your platfo
+set platform      = gfortran    # A unique identifier for your platform
                                 # This corresponds to the mkmf templates in $root/bin dir.
 set type          = MOM_solo    # Type of the experiment
 set unit_testing = 0
@@ -42,7 +42,7 @@ if ( $help ) then
     echo "             ACCESS-CM : ocean component of ACCESS-CM model."
     echo "             ACCESS-OM : ocean component of ACCESS-OM model."
     echo
-    echo "--platform   followed by the platform name that has a corresponfing environ file in the ../bin dir, default is gfortran"
+    echo "--platform   followed by the platform name that has a corresponding environs file in the ../bin dir, default is gfortran"
     echo
     echo "--use_netcdf4  use NetCDF4, the default is NetCDF4. Warning: many of the standard experiments don't work with NetCDF4."
     echo

--- a/src/mom5/ocean_core/ocean_advection_velocity.F90
+++ b/src/mom5/ocean_core/ocean_advection_velocity.F90
@@ -449,7 +449,7 @@ subroutine ocean_advection_velocity_init(Grid, Domain, Time, Time_steps, Thickne
   enddo
   
   max_dt_for_advection = nint(max_dt_for_advection/vertical_factor) ! 
-  max_dt_for_advection =  max_dt_for_advection + 0.001*mpp_pe()     ! to separate redundancies
+  max_dt_for_advection =  max_dt_for_advection + 1.e-12*mpp_pe()     ! to separate redundancies
   max_dt_for_advection0 = max_dt_for_advection
   call mpp_min (max_dt_for_advection)
   call mpp_max (gridmax)

--- a/src/mom5/ocean_core/ocean_velocity.F90
+++ b/src/mom5/ocean_core/ocean_velocity.F90
@@ -852,7 +852,7 @@ end subroutine ocean_velocity_init
        enddo
     enddo
     max_dt_for_cgint = nint(max_dt_for_cgint)
-    max_dt_for_cgint = max_dt_for_cgint + 0.001*mpp_pe() ! to separate redundancies
+    max_dt_for_cgint = max_dt_for_cgint + 1.e-12*mpp_pe() ! to separate redundancies
     max_dt_for_cgint0 = max_dt_for_cgint
     call mpp_min (max_dt_for_cgint)
 

--- a/src/mom5/ocean_param/neutral/ocean_nphysics_diff.F90
+++ b/src/mom5/ocean_param/neutral/ocean_nphysics_diff.F90
@@ -589,7 +589,7 @@ contains
     min_delta(COMP,:) = min_xy_dz(COMP,:)/(2*aredi_array(COMP,:)*dtime + epsln)
 
     delta_iso = minval(min_delta(COMP,:), mask=Grid%tmask(COMP,:)==1.0)
-    delta_iso = delta_iso + 1.e-6*mpp_pe() ! to separate redundancies
+    delta_iso = delta_iso + 1.e-12*mpp_pe() ! to separate redundancies
     delta_iso0 = delta_iso
     call mpp_min (delta_iso)
 
@@ -621,7 +621,7 @@ contains
 
     ! Compute maximum diffusivity available given a maximum slope of smax
     delta_min = minval(min_xy_dz(COMP,:), mask=Grid%tmask(COMP,:)==1.0)
-    A_max = delta_min/(2*smax*dtime + epsln) + 1.e-6*mpp_pe() ! to separate redundancies
+    A_max = delta_min/(2*smax*dtime + epsln) + 1.e-12*mpp_pe() ! to separate redundancies
     A_max0 = A_max
     call mpp_min (A_max)    
 

--- a/src/mom5/ocean_param/neutral/ocean_nphysics_util.F90
+++ b/src/mom5/ocean_param/neutral/ocean_nphysics_util.F90
@@ -1846,7 +1846,7 @@ subroutine ocean_nphysics_coeff_init(Time, Thickness, rossby_radius, rossby_radi
       enddo
     enddo
   enddo
-  delta_iso  = delta_iso + 1.e-6*mpp_pe() ! to separate redundancies
+  delta_iso  = delta_iso + 1.e-12*mpp_pe() ! to separate redundancies
   delta_iso0 = delta_iso
   call mpp_min (delta_iso)
 
@@ -1890,7 +1890,7 @@ subroutine ocean_nphysics_coeff_init(Time, Thickness, rossby_radius, rossby_radi
       enddo
     enddo
   enddo
-  A_max  = ft*delta_min + 1.e-6*mpp_pe() ! to separate redundancies
+  A_max  = ft*delta_min + 1.e-12*mpp_pe() ! to separate redundancies
   A_max0 = A_max
   call mpp_min (A_max)
 


### PR DESCRIPTION
As discussed here: 
https://arccss.slack.com/archives/C6PP0GU9Y/p1516678999000106
but `modules.nci` is now called `environs.access-om2.nci`
and specifies `openmpi/1.10.2`, not `openmpi/3.0.0`

There are related pull requests for the other model components.

There's also a small bug fix for splitting redundancies for >999 cpus.