### PR TITLE
Fixed bug with calling redsea_gulfbay_fix

### DIFF
--- a/src/access_coupler/ocean_solo.F90
+++ b/src/access_coupler/ocean_solo.F90
@@ -125,7 +125,7 @@ program main
 !     </PRE>
 !   </NOTE>
 !
-  use constants_mod,            only: constants_init
+  use constants_mod,            only: constants_init, SECONDS_PER_HOUR
   use data_override_mod,        only: data_override_init, data_override
   use diag_manager_mod,         only: diag_manager_init, diag_manager_end
   use field_manager_mod,        only: field_manager_init
@@ -172,6 +172,8 @@ program main
   type(time_type) :: Time_restart_init
   type(time_type) :: Time_restart
   type(time_type) :: Time_restart_current
+  type(time_type) :: Time_last_sfix 
+  type(time_type) :: Time_sfix 
 
   character(len=17) :: calendar = 'julian'
 
@@ -307,6 +309,7 @@ program main
   num_cpld_calls    = Run_len / Time_step_coupled
   Time = Time_start
   Time_last_sfix = Time_start
+  Time_sfix = set_time(seconds=int(sfix_hours*SECONDS_PER_HOUR))
 
   Time_restart_init = set_date(date_restart(1), date_restart(2), date_restart(3),  &
                                date_restart(4), date_restart(5), date_restart(6) )
@@ -434,7 +437,7 @@ program main
      endif
 
 #ifdef ACCESS
-     if ((Time - Time_last_sfix) >= sfix_hours*SECONDS_PER_HOUR) then
+     if ((Time - Time_last_sfix) >= Time_sfix) then
         do_sfix_now = .true.
         Time_last_sfix = Time
      else

--- a/src/access_coupler/ocean_solo.F90
+++ b/src/access_coupler/ocean_solo.F90
@@ -306,6 +306,7 @@ program main
   Time_step_coupled = set_time(dt_cpld, 0)
   num_cpld_calls    = Run_len / Time_step_coupled
   Time = Time_start
+  Time_last_sfix = Time_start
 
   Time_restart_init = set_date(date_restart(1), date_restart(2), date_restart(3),  &
                                date_restart(4), date_restart(5), date_restart(6) )
@@ -433,9 +434,12 @@ program main
      endif
 
 #ifdef ACCESS
-     do_sfix_now = .false.
-     int_sec = (nc-1) * num_cpld_calls
-     if (mod((nc-1)*num_cpld_calls,sfix_hours*3600) == 0 .and. nc /= 1) do_sfix_now = .true.
+     if ((Time - Time_last_sfix) >= sfix_hours*SECONDS_PER_HOUR) then
+        do_sfix_now = .true.
+        Time_last_sfix = Time
+     else
+        do_sfix_now = .false.
+     end if
 #endif
 
      call update_ocean_model(Ice_ocean_boundary, Ocean_state, Ocean_sfc, Time, Time_step_coupled)

--- a/src/access_coupler/ocean_solo.F90
+++ b/src/access_coupler/ocean_solo.F90
@@ -172,8 +172,10 @@ program main
   type(time_type) :: Time_restart_init
   type(time_type) :: Time_restart
   type(time_type) :: Time_restart_current
+#ifdef ACCESS
   type(time_type) :: Time_last_sfix 
   type(time_type) :: Time_sfix 
+#endif
 
   character(len=17) :: calendar = 'julian'
 
@@ -308,8 +310,10 @@ program main
   Time_step_coupled = set_time(dt_cpld, 0)
   num_cpld_calls    = Run_len / Time_step_coupled
   Time = Time_start
+#ifdef ACCESS
   Time_last_sfix = Time_start
   Time_sfix = set_time(seconds=int(sfix_hours*SECONDS_PER_HOUR))
+#endif
 
   Time_restart_init = set_date(date_restart(1), date_restart(2), date_restart(3),  &
                                date_restart(4), date_restart(5), date_restart(6) )

--- a/src/mom5/ocean_core/ocean_model.F90
+++ b/src/mom5/ocean_core/ocean_model.F90
@@ -218,7 +218,7 @@ use mpp_mod,                  only: mpp_clock_id, mpp_clock_begin, mpp_clock_end
 use mpp_mod,                  only: CLOCK_COMPONENT, CLOCK_SUBCOMPONENT, CLOCK_MODULE, CLOCK_ROUTINE
 use stock_constants_mod,      only: ISTOCK_WATER, ISTOCK_HEAT, ISTOCK_SALT
 use time_interp_external_mod, only: time_interp_external_init
-use time_manager_mod,         only: JULIAN, get_date, get_time
+use time_manager_mod,         only: JULIAN, get_date, get_time, print_time
 use time_manager_mod,         only: time_type, operator( /= ), operator( < ), operator ( / )
 use time_manager_mod,         only: set_time, operator(-), operator( + ), operator( == )
 use time_manager_mod,         only: operator(*)
@@ -2050,7 +2050,7 @@ subroutine ocean_model_init(Ocean, Ocean_state, Time_init, Time_in)
     if (redsea_gulfbay_sfix .and. do_sfix_now) then
         call mpp_clock_begin(id_sfix)
         if (mpp_pe() == mpp_root_pe()) then
-            write(stdoutunit,*) 'Calling redsea_gulfbay_hmix_s at runtime = ',Time
+            call print_time(time_start_update, 'Calling redsea_gulfbay_hmix_s at runtime = ')
         endif
         call redsea_gulfbay_hmix_s(Time, Grid, Thickness, &
                                    T_prog(1:num_prog_tracers), Ocean_sfc)

--- a/src/mom5/ocean_core/ocean_model.F90
+++ b/src/mom5/ocean_core/ocean_model.F90
@@ -331,7 +331,7 @@ use ocean_wave_mod,               only: ocean_wave_init, ocean_wave_end, ocean_w
 
 #if defined(ACCESS)
   use auscom_ice_mod, only: auscom_ice_init
-  use auscom_ice_parameters_mod,  only: redsea_gulfbay_sfix, do_sfix_now, int_sec
+  use auscom_ice_parameters_mod,  only: redsea_gulfbay_sfix, do_sfix_now
   use mpp_mod,                    only: mpp_pe, mpp_root_pe
 #endif
 
@@ -2050,7 +2050,7 @@ subroutine ocean_model_init(Ocean, Ocean_state, Time_init, Time_in)
     if (redsea_gulfbay_sfix .and. do_sfix_now) then
         call mpp_clock_begin(id_sfix)
         if (mpp_pe() == mpp_root_pe()) then
-            write(stdoutunit,*) 'Calling redsea_gulfbay_hmix_s at runtime = ',int_sec
+            write(stdoutunit,*) 'Calling redsea_gulfbay_hmix_s at runtime = ',Time
         endif
         call redsea_gulfbay_hmix_s(Time, Grid, Thickness, &
                                    T_prog(1:num_prog_tracers), Ocean_sfc)


### PR DESCRIPTION
There was a bug in the logic for calling the `redsea_gulfbay_fix` in ACCESS models detailed here

https://github.com/OceansAus/access-om2/issues/83

This is a fix for this bug. It has been tested with a 1 deg ACCESS-OM2 configuration.