### PR TITLE
sat_vapor_pres init, fms_io_exit ordering

### DIFF
--- a/src/coupler/coupler_main.F90
+++ b/src/coupler/coupler_main.F90
@@ -1520,8 +1520,8 @@ contains
     !----- write restart file ------
     call coupler_restart(Time, Time_restart_current)
 
-    call fms_io_exit
     call diag_manager_end (Time)
+    call fms_io_exit
     call mpp_set_current_pelist()
 
 !-----------------------------------------------------------------------

--- a/src/mom5/ocean_core/ocean_model.F90
+++ b/src/mom5/ocean_core/ocean_model.F90
@@ -333,6 +333,8 @@ use ocean_wave_mod,               only: ocean_wave_init, ocean_wave_end, ocean_w
   use auscom_ice_mod, only: auscom_ice_init
   use auscom_ice_parameters_mod,  only: redsea_gulfbay_sfix, do_sfix_now
   use mpp_mod,                    only: mpp_pe, mpp_root_pe
+#else
+  use sat_vapor_pres_mod,         only: sat_vapor_pres_init
 #endif
 
 #ifdef ENABLE_ODA    
@@ -1340,6 +1342,8 @@ subroutine ocean_model_init(Ocean, Ocean_state, Time_init, Time_in)
     call ocean_wave_init(Grid, Domain, Waves, Time, Time_steps, Ocean_options, debug)
 #if defined(ACCESS)
     call auscom_ice_init(Ocean%domain, Time_steps)
+#else
+    call sat_vapor_pres_init()
 #endif
 
 #ifdef ENABLE_ODA    


### PR DESCRIPTION
This patch consists of two minor changes, which enable compatibility
with the newer FMS release (warsaw).

- We now explicitly initialise the `sat_vapor_pres_mod` module.

  Older FMS versions would automatically initialise this module on first
  use.  The newer release requires explicit initialisation.

- `fms_io_exit` now called after `diag_manager_end`.

  A new implementation of the `write_version_number` function will
  automatically initialise `fms_io_mod` if it has been uninitialised.

  This causes errors if `fms_io_exit` has been called, which
  de-initialises the function but does not expicitly deallocate its
  internal arrays.  Since `diag_manager_end` calls
  `write_version_number`, it will try to re-initialise `fms_io_mod` and
  reallocate arrays which are already allocated.

  While FMS probably ought to re-allocate these variables, there is no
  reason to re-initialise FMS in this case.  Instead, we re-order these
  functions so that `fms_io_exit` is called after `diag_manager_end`.