### PR TITLE
Convert data source paths to URLs

### DIFF
--- a/data/get_exp_data.py
+++ b/data/get_exp_data.py
@@ -78,6 +78,10 @@ def main():
     # Possibly try multiple sources to get file. 
     ret = 0
     for url in src_dict[args.filename]:
+        # Convert local paths to URLs
+        if os.path.isfile(url):
+            url = 'file://' + url
+
         is_local_path, local_path = get_local_path(url)
 
         if local_path is not None:


### PR DESCRIPTION
In `data_sources.csv`, some target data files are preceded bya URL
(file://) while others are simply filepaths.  This appears to cause
problems when wget tries to read them, creating empty files with the
same name.

This patch forces local paths to be redefined as URLs if they exist.
Not fool-proof, but a slight improvement.