### PR TITLE
Updates to temperature - binned heat budget diagnostics

### DIFF
--- a/src/mom5/ocean_param/neutral/ocean_nphysicsC.F90
+++ b/src/mom5/ocean_param/neutral/ocean_nphysicsC.F90
@@ -2034,7 +2034,7 @@ subroutine compute_gmskewsion(Time, Thickness, Dens, T_prog)
         call diagnose_3d(Time, Grd, id_neutral_physics_gm(n), T_prog(n)%wrk1(:,:,:)*T_prog(n)%conversion)
      endif
      if(id_neutral_physics_gm_on_nrho(n) > 0) then 
-        call diagnose_3d_rho(Time, Dens, id_neutral_physics_gm(n), T_prog(n)%wrk1*T_prog(n)%conversion)
+        call diagnose_3d_rho(Time, Dens, id_neutral_physics_gm_on_nrho(n), T_prog(n)%wrk1*T_prog(n)%conversion)
      endif
 
      ! send fluxes to diag_manager 


### PR DESCRIPTION
These commits update the previous neutrho_is_temp changes (#202) to:
     1. Fix a bug in the GM temperature-binned diagnostic
     2. Add a diagnostic to bin the mixdownslope term (on in ACCESS-OM2)
     3. Clean up the neutral_rho_equal_theta option in ocean_density to be consistent with neutral_rho_potrho option and provide proper messages to mom.out

Has been tested on a MOM-SIS 1/4-degree config and the new ACCESS-OM2-1degree (with yatm).
        
Note that I have not yet included diagnostics to bin the following heat budget terms: 
  temp_sigma_diff, temp_xlandmix, temp_xlandinsert, temp_runoffmix, temp_calvingmix, geo_heat
These are not active in the configurations I am using. I'm happy to do this if anyone would like these terms in the future, just point me at a test case.

Note also that this pull request reverts some unintentional changes to the neutral_rho_equal_theta option (now neutral_density_theta) introduced by APE changes #210 (https://github.com/mom-ocean/MOM5/pull/211).