### PR TITLE
Langmuir turbulence enhance factor via cvmix method based on Van Roekel 2012 (from Russ)

### DIFF
--- a/src/coupler/flux_exchange.F90
+++ b/src/coupler/flux_exchange.F90
@@ -1036,6 +1036,7 @@ subroutine flux_exchange_init ( Time, Atm, Land, Ice, Ocean, Ocean_state,&
     allocate( ice_ocean_boundary%calving_hflx  (is:ie,js:je) ) ; ice_ocean_boundary%calving_hflx = 0.0
     allocate( ice_ocean_boundary%p        (is:ie,js:je) ) ; ice_ocean_boundary%p = 0.0
     allocate( ice_ocean_boundary%mi       (is:ie,js:je) ) ; ice_ocean_boundary%mi = 0.0
+    allocate( ice_ocean_boundary%wnd      (is:ie,js:je) ) ;         ice_ocean_boundary%wnd = 0.0
 
 !
 ! allocate fields for extra tracers
@@ -1785,6 +1786,8 @@ subroutine sfc_boundary_layer ( dt, Time, Atm, Land, Ice, Land_Ice_Atmos_Boundar
   endif
 #endif
 
+! place the wind value onto the ice data type.  mac ! Check  RASF
+  call get_from_xgrid (Ice%wnd, 'OCN', ex_u10, xmap_sfc)
   !=======================================================================
   ! [7] diagnostics section
 
@@ -2775,6 +2778,7 @@ subroutine flux_ice_to_ocean ( Time, Ice, Ocean, Ice_Ocean_Boundary )
 !                                         runoff_ocean,  calving_ocean, &
 !                                         flux_salt_ocean, p_surf_ocean
   type(ice_ocean_boundary_type), intent(inout) :: Ice_Ocean_Boundary
+  real, dimension(:,:), pointer                :: dummy_null_pointer => NULL() !  RASF hack to get around pointer association.
 
   integer       :: m
   integer       :: n
@@ -2850,6 +2854,16 @@ subroutine flux_ice_to_ocean ( Time, Ice, Ocean, Ice_Ocean_Boundary )
   if(ASSOCIATED(Ice_Ocean_Boundary%q_flux) ) call flux_ice_to_ocean_redistribute( Ice, Ocean, &
       Ice%flux_q, Ice_Ocean_Boundary%q_flux, Ice_Ocean_Boundary%xtype, do_area_weighted_flux )
 
+  if(ASSOCIATED(Ice_Ocean_Boundary%wnd) ) then
+     if(ASSOCIATED(Ice%wnd)) then
+        call flux_ice_to_ocean_redistribute( Ice, Ocean, &
+           Ice%wnd(:,:,1), Ice_Ocean_Boundary%wnd, Ice_Ocean_Boundary%xtype, do_area_weighted_flux )
+     else
+        call flux_ice_to_ocean_redistribute( Ice, Ocean, &
+          dummy_null_pointer, Ice_Ocean_Boundary%wnd, Ice_Ocean_Boundary%xtype, do_area_weighted_flux ) !Put dummy array here.
+     endif
+  endif
+
 !Balaji: moved data_override calls here from coupler_main
   if( ocn_pe )then
       call mpp_set_current_pelist(ocn_pelist)
@@ -2857,6 +2871,7 @@ subroutine flux_ice_to_ocean ( Time, Ice, Ocean, Ice_Ocean_Boundary )
       call data_override('OCN', 'v_flux',    Ice_Ocean_Boundary%v_flux   , Time )
       call data_override('OCN', 't_flux',    Ice_Ocean_Boundary%t_flux   , Time )
       call data_override('OCN', 'q_flux',    Ice_Ocean_Boundary%q_flux   , Time )
+      call data_override('OCN', 'wnd',    Ice_Ocean_Boundary%wnd   , Time )
       call data_override('OCN', 'salt_flux', Ice_Ocean_Boundary%salt_flux, Time )
       call data_override('OCN', 'lw_flux',   Ice_Ocean_Boundary%lw_flux  , Time )
       call data_override('OCN', 'sw_flux_nir_dir',   Ice_Ocean_Boundary%sw_flux_nir_dir  , Time )

--- a/src/ice_sis/ice_model.F90
+++ b/src/ice_sis/ice_model.F90
@@ -67,7 +67,7 @@ module ice_model_mod
                               add_diurnal_sw, id_mib, ice_data_type_chksum,      &
                               id_ustar, id_vstar, channel_viscosity, smag_ocn,   &
                               ssh_gravity, chan_cfl_limit, id_vocean, id_uocean, &
-                              id_vchan, id_uchan
+                              id_vchan, id_uchan, id_wnd
   use ice_type_mod,     only: do_sun_angle_for_alb,              &
 			      id_alb_vis_dir, id_alb_vis_dif,    &
 	                      id_alb_nir_dir, id_alb_nir_dif
@@ -1456,6 +1456,8 @@ contains
          !                                       mask=Ice%mask       )
 
     if (id_ext>0) sent = send_data(id_ext, ext(Ice%part_size(isc:iec,jsc:jec,1)), Ice%Time, mask=Ice%mask)
+    if (id_wnd>0) sent = send_data(id_wnd, Ice%wnd(isc:iec,jsc:jec,1), Ice%Time, mask=Ice%mask)
+
     if (id_hs>0) sent  = send_data(id_hs, ice_avg(Ice%h_snow(isc:iec,jsc:jec,:),Ice%part_size(isc:iec,jsc:jec,:)), &
                          Ice%Time, mask=Ice%mask)
     if (id_hi>0) sent  = send_data(id_hi, ice_avg(Ice%h_ice(isc:iec,jsc:jec,:) ,Ice%part_size(isc:iec,jsc:jec,:)), &

--- a/src/mom5/drivers/ocean_solo.F90
+++ b/src/mom5/drivers/ocean_solo.F90
@@ -357,7 +357,8 @@ ierr = check_nml_error(io_status,'ocean_solo_nml')
              Ice_ocean_boundary% fprec (isc:iec,jsc:jec),           &
              Ice_ocean_boundary% runoff (isc:iec,jsc:jec),          &
              Ice_ocean_boundary% calving (isc:iec,jsc:jec),         &
-             Ice_ocean_boundary% p (isc:iec,jsc:jec))
+             Ice_ocean_boundary% p (isc:iec,jsc:jec),               &
+             Ice_ocean_boundary% wnd (isc:iec,jsc:jec))
 
   Ice_ocean_boundary%u_flux          = 0.0
   Ice_ocean_boundary%v_flux          = 0.0
@@ -374,6 +375,7 @@ ierr = check_nml_error(io_status,'ocean_solo_nml')
   Ice_ocean_boundary%runoff          = 0.0
   Ice_ocean_boundary%calving         = 0.0
   Ice_ocean_boundary%p               = 0.0
+  Ice_ocean_boundary%wnd             = 0.0
 
   call external_coupler_sbc_init(Ocean_sfc%domain, dt_cpld, Run_len)
 
@@ -500,6 +502,7 @@ end subroutine ocean_solo_restart
       call data_override('OCN', 'runoff',          x%runoff         , Time_next)
       call data_override('OCN', 'calving',         x%calving        , Time_next)
       call data_override('OCN', 'p',               x%p              , Time_next)
+      call data_override('OCN', 'wnd',             x%wnd            , Time_next)
             
   end subroutine ice_ocn_bnd_from_data
 

--- a/src/mom5/ocean_core/ocean_model.F90
+++ b/src/mom5/ocean_core/ocean_model.F90
@@ -3358,5 +3358,3 @@ subroutine ice_ocn_bnd_type_chksum(id, timestep, iobt)
 end subroutine ice_ocn_bnd_type_chksum
 
 end module ocean_model_mod
-  
-:q!

--- a/src/mom5/ocean_core/ocean_model.F90
+++ b/src/mom5/ocean_core/ocean_model.F90
@@ -380,9 +380,6 @@ private
   real, dimension(isd:ied,jsd:jed)      :: bott_blthick  ! bottom boundary layer depth from sigma transport (m)
   real, dimension(isd:ied,jsd:jed)      :: rossby_radius ! rossby radius (m)
   real, dimension(isd:ied,jsd:jed,nk)   :: swheat        ! external shortwave heating source W/m^2
-#if defined(ACCESS)
-  real, dimension(isd:ied,jsd:jed)      :: aice          ! ice fraction
-#endif
 
 #else
 
@@ -409,9 +406,6 @@ private
   real, pointer, dimension(:,:)     :: bott_blthick        =>NULL() ! bottom boundary layer depth from sigma transport (m)
   real, pointer, dimension(:,:)     :: rossby_radius       =>NULL() ! rossby radius (m) 
   real, pointer, dimension(:,:,:)   :: swheat              =>NULL() ! external shortwave heating source W/m^2
-#if defined(ACCESS)
-  real, pointer, dimension(:,:)     :: aice                =>NULL() ! ice fraction
-#endif
 
 #endif
 
@@ -1204,9 +1198,6 @@ subroutine ocean_model_init(Ocean, Ocean_state, Time_init, Time_in, &
     allocate(bott_blthick(isd:ied,jsd:jed))    
     allocate(rossby_radius(isd:ied,jsd:jed))    
     allocate(swheat(isd:ied,jsd:jed,nk))
-#if defined(ACCESS)
-    allocate(aice(isd:ied,jsd:jed))
-#endif
 
 #endif
 #if defined (ENABLE_ODA) && defined (ENABLE_ECDA)
@@ -1585,27 +1576,16 @@ subroutine ocean_model_init(Ocean, Ocean_state, Time_init, Time_in, &
 
        ! obtain surface boundary fluxes from coupler
        call mpp_clock_begin(id_sbc)
-#if defined(ACCESS)
-       call get_ocean_sbc(Time, Ice_ocean_boundary, Thickness, Dens, Ext_mode,       &
-            T_prog(1:num_prog_tracers), Velocity, pme, melt, river, runoff, calving, &
-            upme, uriver, swflx, swflx_vis, patm, aice)
-#else
        call get_ocean_sbc(Time, Ice_ocean_boundary, Thickness, Dens, Ext_mode,       &
             T_prog(1:num_prog_tracers), Velocity, pme, melt, river, runoff, calving, &
             upme, uriver, swflx, swflx_vis, patm)
-#endif
        call mpp_clock_end(id_sbc)
 
        ! compute "flux adjustments" (e.g., surface tracer restoring, flux correction)
        call mpp_clock_begin(id_flux_adjust)
-#if defined(ACCESS)
-       call flux_adjust(Time, T_diag(1:num_diag_tracers), Dens, Ext_mode, &
-                        T_prog(1:num_prog_tracers), Velocity, river, melt, pme, aice)
-#else
        call flux_adjust(Time, T_diag(1:num_diag_tracers), Dens, Ext_mode, &
                         T_prog(1:num_prog_tracers), Velocity, river, melt, pme)
 
-#endif
        call mpp_clock_end(id_flux_adjust)
 
        ! calculate bottom momentum fluxes and bottom tracer fluxes
@@ -3379,3 +3359,4 @@ end subroutine ice_ocn_bnd_type_chksum
 
 end module ocean_model_mod
   
+:q!

--- a/src/mom5/ocean_core/ocean_sbc.F90
+++ b/src/mom5/ocean_core/ocean_sbc.F90
@@ -761,6 +761,7 @@ real, allocatable, dimension(:,:) :: betasfc2      ! potrho surface saline contr
 #endif
 #if defined(ACCESS)
 real, allocatable, dimension(:,:,:) :: sslope
+real, allocatable, dimension(:,:) :: aice
 #endif
 
 
@@ -1046,6 +1047,7 @@ subroutine ocean_sbc_init(Grid, Domain, Time, T_prog, T_diag, &
 #if defined(ACCESS)
   allocate ( Ocean_sfc%gradient (isc_bnd:iec_bnd,jsc_bnd:jec_bnd,2))
   allocate ( sslope(isc:iec, jsc:jec, 2) )
+  allocate ( aice(isc:iec, jsc:jec) )
 #if defined(ACCESS_CM)
   allocate ( Ocean_sfc%co2    (isc_bnd:iec_bnd,jsc_bnd:jec_bnd), &
              Ocean_sfc%co2flux (isc_bnd:iec_bnd,jsc_bnd:jec_bnd)) 
@@ -1062,6 +1064,7 @@ subroutine ocean_sbc_init(Grid, Domain, Time, T_prog, T_diag, &
 #if defined(ACCESS)
   Ocean_sfc%gradient  = 0.0  ! gradint of ssl passed to Ice model
   sslope = 0.0
+  aice = 0.0
 #if defined(ACCESS_CM)
   Ocean_sfc%co2       = 0.0 
   Ocean_sfc%co2flux   = 0.0 
@@ -3127,18 +3130,9 @@ end subroutine ocean_sfc_end
 ! </DESCRIPTION>
 !
 
-#if defined(ACCESS)
-subroutine get_ocean_sbc(Time, Ice_ocean_boundary, Thickness, Dens, Ext_mode, T_prog, Velocity, &
-                         pme, melt, river, runoff, calving, upme, uriver, swflx, swflx_vis, patm, aice)
-
-  real, dimension(isd:,jsd:),    intent(inout)    :: aice 
-
-#else
-
 subroutine get_ocean_sbc(Time, Ice_ocean_boundary, Thickness, Dens, Ext_mode, T_prog, Velocity, &
                          pme, melt, river, runoff, calving, upme, uriver, swflx, swflx_vis, patm)
 
-#endif
 
   type(ocean_time_type),          intent(in)    :: Time 
   type(ice_ocean_boundary_type),  intent(in)    :: Ice_ocean_boundary
@@ -3214,11 +3208,16 @@ subroutine get_ocean_sbc(Time, Ice_ocean_boundary, Thickness, Dens, Ext_mode, T_
           do i = isc_bnd,iec_bnd
              ii = i + i_shift
              jj = j + j_shift
-             Velocity%ustoke(ii,jj) = Ice_ocean_boundary%ustoke(i,j)
-             Velocity%vstoke(ii,jj) = Ice_ocean_boundary%vstoke(i,j)
-             Velocity%wavlen(ii,jj)= Ice_ocean_boundary%wavlen(i,j)
+! until full wave model is implemented Ice_ocean_boundary%ustoke etc not associated 
+             if(associated(Ice_ocean_boundary%ustoke)) then
+                Velocity%ustoke(ii,jj) = Ice_ocean_boundary%ustoke(i,j) 
+                Velocity%vstoke(ii,jj) = Ice_ocean_boundary%vstoke(i,j)
+                Velocity%wavlen(ii,jj)= Ice_ocean_boundary%wavlen(i,j)
+             endif
+             Velocity%u10(ii,jj)= Ice_ocean_boundary%wnd(i,j)*Grd%tmask(ii,jj,1) !RASF 10m winds passin ACCESS, Wombat. c.f. MOM6 approach ustar to u10. T-GRID!
           enddo
        enddo
+       call mpp_update_domains(Velocity%u10(:,:)  , Dom%domain2d)
     endif
   !--------momentum fluxes------------------------------------- 
   !
@@ -4203,16 +4202,10 @@ end subroutine get_ocean_sbc
 ! </DESCRIPTION>
 !
 
+subroutine flux_adjust(Time, T_diag, Dens, Ext_mode, T_prog, Velocity, river, melt, pme)
 #if defined(ACCESS)
 
-subroutine flux_adjust(Time, T_diag, Dens, Ext_mode, T_prog, Velocity, river, melt, pme, aice)
   use auscom_ice_parameters_mod, only : use_ioaice, aice_cutoff
-
-  real, dimension(isd:,jsd:),    intent(in)    :: aice 
-
-#else
-
-subroutine flux_adjust(Time, T_diag, Dens, Ext_mode, T_prog, Velocity, river, melt, pme)
 
 #endif
 

--- a/src/mom5/ocean_core/ocean_types.F90
+++ b/src/mom5/ocean_core/ocean_types.F90
@@ -1098,7 +1098,7 @@ module ocean_types_mod
      real, _ALLOCATABLE, dimension(:,:,:)     :: bmf             _NULL ! momentum flux per mass into ocean bottom  (N/m^2)
      real, _ALLOCATABLE, dimension(:,:)       :: gamma           _NULL ! dimensionful bottom drag coefficient (kg/(m^2 sec))
      real, _ALLOCATABLE, dimension(:,:)       :: langmuirfactor  _NULL ! Langmuir turbulence enhancement factor
-     real, _ALLOCATABLE, dimension(:,:)       :: u10             _NULL ! x-dir surface stokes drift
+     real, _ALLOCATABLE, dimension(:,:)       :: u10             _NULL ! 10m wind speed (m/s)
      real, _ALLOCATABLE, dimension(:,:)       :: ustoke          _NULL ! x-dir surface stokes drift
      real, _ALLOCATABLE, dimension(:,:)       :: vstoke          _NULL ! y-dir surface stokes drift
      real, _ALLOCATABLE, dimension(:,:)       :: wavlen          _NULL ! wave length

--- a/src/mom5/ocean_core/ocean_types.F90
+++ b/src/mom5/ocean_core/ocean_types.F90
@@ -564,6 +564,7 @@ module ocean_types_mod
      real, dimension(isd:ied,jsd:jed,2)      :: bmf             ! momentum flux per mass into ocean bottom  (N/m^2)
      real, dimension(isd:ied,jsd:jed)        :: gamma           ! dimensionful bottom drag coefficient (kg/(m^2 sec))
      real, dimension(isd:ied,jsd:jed)        :: langmuirfactor  ! dimensionless langmuir turbulence enhancement factor (non dimensional)
+     real, dimension(isd:ied,jsd:jed)        :: u10             ! 10m wind speed (m/s)
      real, dimension(isd:ied,jsd:jed)        :: ustoke          ! x-dir surface stokes drift (m/s)
      real, dimension(isd:ied,jsd:jed)        :: vstoke          ! y-dir surface stokes drift (m/s)
      real, dimension(isd:ied,jsd:jed)        :: wavlen          ! wave length (m)
@@ -1097,6 +1098,7 @@ module ocean_types_mod
      real, _ALLOCATABLE, dimension(:,:,:)     :: bmf             _NULL ! momentum flux per mass into ocean bottom  (N/m^2)
      real, _ALLOCATABLE, dimension(:,:)       :: gamma           _NULL ! dimensionful bottom drag coefficient (kg/(m^2 sec))
      real, _ALLOCATABLE, dimension(:,:)       :: langmuirfactor  _NULL ! Langmuir turbulence enhancement factor
+     real, _ALLOCATABLE, dimension(:,:)       :: u10             _NULL ! x-dir surface stokes drift
      real, _ALLOCATABLE, dimension(:,:)       :: ustoke          _NULL ! x-dir surface stokes drift
      real, _ALLOCATABLE, dimension(:,:)       :: vstoke          _NULL ! y-dir surface stokes drift
      real, _ALLOCATABLE, dimension(:,:)       :: wavlen          _NULL ! wave length
@@ -1234,9 +1236,9 @@ module ocean_types_mod
      real, pointer, dimension(:,:) :: wfiform          =>NULL() ! water flux from forming ice (kg/m^2/s)
 #if defined(ACCESS_CM)
      real, pointer, dimension(:,:) :: co2              =>NULL() ! co2
+#endif
+#endif
      real, pointer, dimension(:,:) :: wnd              =>NULL() ! wind speed
-#endif
-#endif
      integer :: xtype                                          ! REGRID, REDIST or DIRECT
 
      type(coupler_2d_bc_type)      :: fluxes                   ! array of fields used for additional tracers

--- a/src/mom5/ocean_core/ocean_velocity.F90
+++ b/src/mom5/ocean_core/ocean_velocity.F90
@@ -412,6 +412,7 @@ subroutine ocean_velocity_init (Grid, Domain, Time, Time_steps, Ocean_options, &
   allocate (Velocity%lap_friction_bt(isd:ied,jsd:jed,2))
   allocate (Velocity%bih_friction_bt(isd:ied,jsd:jed,2))
   allocate (Velocity%current_wave_stress(isd:ied,jsd:jed))
+  allocate (Velocity%u10(isd:ied,jsd:jed))
 #endif
 
   Velocity%smf                 = 0.0
@@ -437,6 +438,7 @@ subroutine ocean_velocity_init (Grid, Domain, Time, Time_steps, Ocean_options, &
   Velocity%lap_friction_bt     = 0.0
   Velocity%bih_friction_bt     = 0.0
   Velocity%current_wave_stress = 0.0
+  Velocity%u10                 = 0.0
 
   ! register fields for diagnostic output
 

--- a/src/mom5/ocean_param/vertical/ocean_vert_kpp_mom4p1.F90
+++ b/src/mom5/ocean_param/vertical/ocean_vert_kpp_mom4p1.F90
@@ -946,7 +946,7 @@ ierr = check_nml_error(io_status,'ocean_vert_kpp_mom4p1_nml')
        Time%model_time, 'wscale from KPP', 'm',                            &
        missing_value = missing_value, range=(/-1.e5,1.e6/))
 
-  id_lang_enh = register_diag_field('ocean_model','lang_enh',Grd%tracer_axes(1:3), &
+  id_lang_enh = register_diag_field('ocean_model','lang_enh',Grd%tracer_axes(1:2), &
        Time%model_time, 'enhancement due to langmuir turbulence', 'none',                            &
        missing_value = missing_value, range=(/0.0,10./))
 

--- a/src/mom5/ocean_param/vertical/ocean_vert_kpp_mom4p1.F90
+++ b/src/mom5/ocean_param/vertical/ocean_vert_kpp_mom4p1.F90
@@ -243,7 +243,7 @@ module ocean_vert_kpp_mom4p1_mod
 !
 !</NAMELIST>
 
-use constants_mod,    only: epsln
+use constants_mod,    only: epsln, pi
 use diag_manager_mod, only: register_diag_field, register_static_field
 use fms_mod,          only: FATAL, NOTE, WARNING, stdout, stdlog
 use fms_mod,          only: write_version_number, open_namelist_file, check_nml_error, close_file
@@ -260,6 +260,7 @@ use ocean_types_mod,       only: ocean_prog_tracer_type, ocean_diag_tracer_type
 use ocean_types_mod,       only: ocean_velocity_type, ocean_density_type
 use ocean_types_mod,       only: ocean_time_type, ocean_time_steps_type, ocean_thickness_type
 use ocean_workspace_mod,   only: wrk1, wrk2, wrk3, wrk4, wrk5
+use ocean_workspace_mod,   only: wrk1_2d, wrk2_2d
 use ocean_util_mod,        only: diagnose_2d, diagnose_3d, diagnose_sum
 use ocean_tracer_util_mod, only: diagnose_3d_rho
 
@@ -279,6 +280,9 @@ private enhance
 private ri_for_kpp 
 private watermass_diag_init
 private watermass_diag 
+
+private get_langmuir_number
+private ust_2_u10_coare3p5
 
 #include <ocean_memory.h>
 
@@ -320,6 +324,8 @@ real, private, dimension(isd:ied,jsd:jed,nk)    :: ghats       ! nonlocal transp
 real, private, dimension(isd:ied,jsd:jed)       :: hblt        ! boundary layer depth with tmask 
 real, private, dimension(isd:ied,jsd:jed)       :: hbl         ! boundary layer depth
 
+real, dimension(isd:ied,jsd:jed)                :: langmuir_factor !  Enhancnement due to langmuir turbulence3
+real, dimension(isd:ied,jsd:jed)                :: langmuir_number !  Langmuir number
 #else
 
 real, dimension(:,:), allocatable      :: bfsfc    ! surface buoyancy forcing    (m^2/s^3)
@@ -358,6 +364,8 @@ real, private, dimension(:,:,:), allocatable :: ghats       ! nonlocal transport
 real, private, dimension(:,:),   allocatable :: hblt        ! boundary layer depth with tmask 
 real, private, dimension(:,:),   allocatable :: hbl         ! boundary layer depth
 
+real, private, dimension(:,:),   allocatable :: langmuir_factor !  Enhancnement due to langmuir turbulence3
+real, private, dimension(:,:),   allocatable :: langmuir_number !  Langmuir number
 #endif
 
 type(wsfc_type), dimension(:), allocatable     :: wsfc
@@ -388,7 +396,7 @@ real :: vtc_flag = 0.0  ! default to the older approach.
 real :: Lgam = 1.04     ! adjustment to non-gradient flux (McWilliam & Sullivan 2000)
 real :: Cw_0 = 0.15     ! eq. (13) in Smyth et al (2002)
 real :: l_smyth = 2.0   ! eq. (13) in Smyth et al (2002)
-real :: LTmax = 5.0     ! maximum Langmuir turbulence enhancement factor (langmuirfactor) allowed
+real :: LTmax = 5.0     ! maximum Langmuir turbulence enhancement factor (langmuir_factor) allowed
 real :: Wstfac = 0.6    ! stability adjustment coefficient, eq. (13) in Smyth et al (2002)
 
 
@@ -442,6 +450,9 @@ integer  :: id_diff_cbt_kpp_s =-1
 integer  :: id_diff_cbt_conv  =-1
 integer  :: id_hblt           =-1
 integer  :: id_ws             =-1
+integer  :: id_lang_enh       =-1
+integer  :: id_lang           =-1
+integer  :: id_u10           =-1
 
 integer  :: id_neut_rho_kpp_nloc          =-1
 integer  :: id_pot_rho_kpp_nloc           =-1
@@ -472,6 +483,8 @@ integer  :: id_tform_salt_kpp_nloc_on_nrho =-1
 logical :: non_local_kpp = .true.  ! enable/disable non-local term in KPP
 logical :: smooth_blmc   = .false. ! smooth boundary layer diffusitivies to remove grid scale noise
 logical :: do_langmuir   = .false. ! whether or not calcualte langmuir turbulence enhance factor
+logical :: do_langmuir_cvmix   = .false. ! whether or not calcualte langmuir turbulence enhance factor via cvmix method based on Van Roekel 2012
+logical :: calculate_u10 = .false. ! If 10m not available the estimate u10 from u_star
 
 integer, parameter :: nni = 890         ! number of values for zehat in the look up table
 integer, parameter :: nnj = 480         ! number of values for ustar in the look up table
@@ -507,7 +520,7 @@ namelist /ocean_vert_kpp_mom4p1_nml/ use_this_module, shear_instability, double_
                                      use_sbl_bottom_flux, wsfc_combine_runoff_calve,        &
 			             bvf_from_below, variable_vtc, use_max_shear,           &
 			             linear_hbl, calc_visc_on_cgrid, smooth_ri_kmax_eq_kmu, &
-                                     do_langmuir
+                                     do_langmuir, do_langmuir_cvmix, calculate_u10
                                  
 
 contains
@@ -675,6 +688,18 @@ ierr = check_nml_error(io_status,'ocean_vert_kpp_mom4p1_nml')
   else
     write(stdoutunit,'(1x,a)') '==> NOTE from ocean_vert_kpp_mom4p1_mod: Leave full sw-radiation in non-local surface flux.'
   endif
+
+  if(do_langmuir .and. .not. do_langmuir_cvmix) then
+    write(stdoutunit,'(1x,a)') '==> NOTE from ocean_vert_kpp_mom4p1_mod: Enhancing mixing via langmuir turbulence according to Smyth 2002.'
+  endif
+  if(do_langmuir .and. do_langmuir_cvmix) then
+    write(stdoutunit,'(1x,a)') '==> NOTE from ocean_vert_kpp_mom4p1_mod: Enhancing mixing via langmuir turbulence according to van Roekel 2012.'
+  endif
+
+  if( calculate_u10 ) then
+    write(stdoutunit,'(1x,a)') '==> NOTE from ocean_vert_kpp_mom4p1_mod: Calculating U_10 on T-grid from ustar  COARE 3.5 paper (Edson et al., 2013).'
+  endif
+
   
   if(radiation_large .and. radiation_zero) call mpp_error(FATAL,&
       '==>ocean_vert_kpp_mom4p1_mod: Do not enable radiation_large and radiation_zero together. ')   
@@ -762,6 +787,8 @@ ierr = check_nml_error(io_status,'ocean_vert_kpp_mom4p1_nml')
   allocate (dat1(isd:ied,jsd:jed,3))
   allocate(sw_frac_hbl(isd:ied,jsd:jed))
 
+  allocate (langmuir_factor(isd:ied,jsd:jed))
+  allocate (langmuir_number(isd:ied,jsd:jed))
 #endif
 
   kbl(:,:)         = 0
@@ -772,6 +799,7 @@ ierr = check_nml_error(io_status,'ocean_vert_kpp_mom4p1_nml')
   hbl(:,:)         = 0.0
   sw_frac_hbl(:,:) = 0.0
   Ustk2(:,:)       = 0.0
+  ustar            = 0.0
 
   do n = 1, num_prog_tracers  
     wsfc(n)%wsfc(:,:) = 0.0
@@ -918,6 +946,18 @@ ierr = check_nml_error(io_status,'ocean_vert_kpp_mom4p1_nml')
        Time%model_time, 'wscale from KPP', 'm',                            &
        missing_value = missing_value, range=(/-1.e5,1.e6/))
 
+  id_lang_enh = register_diag_field('ocean_model','lang_enh',Grd%tracer_axes(1:3), &
+       Time%model_time, 'enhancement due to langmuir turbulence', 'none',                            &
+       missing_value = missing_value, range=(/0.0,10./))
+
+  id_lang = register_diag_field('ocean_model','lang_num',Grd%tracer_axes(1:2), &
+       Time%model_time, 'Langmuir number', 'none',                            &
+       missing_value = missing_value, range=(/0.0,1.E10/))
+
+  id_u10 = register_diag_field('ocean_model','u10',Grd%tracer_axes(1:2), &
+       Time%model_time, '10m wind speed used for kpp Langmuir turbulence', 'm/s',                            &
+       missing_value = missing_value, range=(/0.0,1.e3/))
+
   call watermass_diag_init(Time,Dens)
 
 
@@ -964,7 +1004,7 @@ subroutine vert_mix_kpp_mom4p1 (aidif, Time, Thickness, Velocity, T_prog, T_diag
   real,                            intent(in)    :: aidif
   type(ocean_time_type),           intent(in)    :: Time
   type(ocean_thickness_type),      intent(in)    :: Thickness
-  type(ocean_velocity_type),       intent(in)    :: Velocity
+  type(ocean_velocity_type),       intent(inout) :: Velocity
   type(ocean_prog_tracer_type),    intent(inout) :: T_prog(:)
   type(ocean_diag_tracer_type),    intent(in)    :: T_diag(:)
   type(ocean_density_type),        intent(in)    :: Dens
@@ -1191,6 +1231,17 @@ subroutine vert_mix_kpp_mom4p1 (aidif, Time, Thickness, Velocity, T_prog, T_diag
         enddo
       enddo
 
+
+! May need to estimate u_10 from ustar. Copy method from MOM6 RASF
+      if ( calculate_u10 ) then
+         where(ustar > 0.0 )
+            Velocity%u10 = ust_2_u10_coare3p5(ustar*sqrt(rho0/1.225))
+         elsewhere
+            Velocity%u10 = 0.0
+         end where
+      endif
+      if(id_u10 > 0) call diagnose_2d(Time, Grd, id_u10, Velocity%u10(:,:))
+
 !-----------------------------------------------------------------------
 !     compute interior mixing coefficients everywhere, due to constant 
 !     internal wave activity, static instability, and local shear 
@@ -1224,14 +1275,16 @@ subroutine vert_mix_kpp_mom4p1 (aidif, Time, Thickness, Velocity, T_prog, T_diag
 !     boundary layer mixing coefficients: diagnose new b.l. depth
 !-----------------------------------------------------------------------
 
-      call bldepth(Thickness, sw_frac_zt, do_wave) 
+      call bldepth(Thickness, Velocity, sw_frac_zt, do_wave) 
  
 !-----------------------------------------------------------------------
 !     boundary layer diffusivities
 !-----------------------------------------------------------------------
 
-      call blmix_kpp(Thickness, diff_cbt, visc_cbu, do_wave)
+      call blmix_kpp(Thickness, Velocity, diff_cbt, visc_cbu, do_wave)
       call diagnose_3d(Time, Grd, id_ws, wrk1(:,:,:))
+      call diagnose_2d(Time, Grd, id_lang_enh, wrk1_2d(:,:))
+      call diagnose_2d(Time, Grd, id_lang, wrk2_2d(:,:))
 
 !-----------------------------------------------------------------------
 !     enhance diffusivity at interface kbl - 1
@@ -1591,9 +1644,10 @@ end subroutine vert_mix_kpp_mom4p1
 !      integer kbl(ij_bounds)     ! index of first grid level below hbl         <BR/>
 ! </DESCRIPTION>
 !
-subroutine bldepth(Thickness, sw_frac_zt, do_wave)
+subroutine bldepth(Thickness, Velocity, sw_frac_zt, do_wave)
 
   type(ocean_thickness_type),   intent(in) :: Thickness
+  type(ocean_velocity_type),   intent(in) :: Velocity
   real, dimension(isd:,jsd:,:), intent(in) :: sw_frac_zt   !3-D array of shortwave fract
   logical, intent(in)                      :: do_wave
 
@@ -1662,7 +1716,7 @@ subroutine bldepth(Thickness, sw_frac_zt, do_wave)
 
         ! compute velocity scales at sigma, for hbl = zt(kl):
         iwscale_use_hbl_eq_zt=1
-        call wscale (iwscale_use_hbl_eq_zt, Thickness%depth_zt(:,:,kl), do_wave)
+        call wscale (iwscale_use_hbl_eq_zt, Thickness%depth_zt(:,:,kl), Velocity, do_wave)
 
         do j=jsc,jec
           do i=isc,iec
@@ -1764,7 +1818,7 @@ subroutine bldepth(Thickness, sw_frac_zt, do_wave)
           
           !  compute velocity scales at sigma, for hbl = zt(kl):
           iwscale_use_hbl_eq_zt=1
-          call wscale (iwscale_use_hbl_eq_zt, Thickness%depth_zt(:,:,kl), do_wave)
+          call wscale (iwscale_use_hbl_eq_zt, Thickness%depth_zt(:,:,kl), Velocity, do_wave)
 
           do j=jsc,jec
             do i=isc,iec
@@ -2006,6 +2060,7 @@ end subroutine bldepth
 !      real hbl(ij_bounds)    = boundary layer depth (m)               <BR/>  
 !      real ustar(ij_bounds)  = surface friction velocity    (m/s)     <BR/>  
 !      real bfsfc(ij_bounds)  = total surface buoyancy flux (m^2/s^3)  <BR/>
+!      velocity structure.                                             <BR/>
 
 !  output                                                               <BR/>  
 !      real wm(ij_bounds),ws(ij_bounds) ! turbulent velocity scales at sigma
@@ -2018,14 +2073,15 @@ end subroutine bldepth
 ! Speed gain was observed at the SX-6.
 ! Later compiler versions may do better.
 !
-subroutine wscale(iwscale_use_hbl_eq_zt, zt_kl, do_wave)
+subroutine wscale(iwscale_use_hbl_eq_zt, zt_kl, Velocity, do_wave)
 
   integer,                    intent(in) :: iwscale_use_hbl_eq_zt
   real, dimension(isd:,jsd:), intent(in) :: zt_kl
+  type(ocean_velocity_type),  intent(in) :: Velocity
   logical,                    intent(in) :: do_wave
 
   real                :: zdiff, udiff, zfrac, ufrac, fzfrac
-  real                :: wam, wbm, was, wbs, u3, langmuirfactor, Cw_smyth
+  real                :: wam, wbm, was, wbs, u3, Cw_smyth
   real                :: zehat           ! = zeta *  ustar**3
   integer             :: iz, izp1, ju, jup1
   integer             :: i, j
@@ -2121,18 +2177,31 @@ subroutine wscale(iwscale_use_hbl_eq_zt, zt_kl, do_wave)
 
 !----------- if do_wave, add Langmuir turbulence enhancement factor
 
-      if (do_wave .and. do_langmuir) then
-         do j=jsc,jec
-            do i=isc,iec
-               Cw_smyth=Cw_0*(ustar(i,j)*ustar(i,j)*ustar(i,j)/(ustar(i,j)*ustar(i,j)*ustar(i,j) &
-                    + Wstfac*von_karman*bfsfc(i,j)*hbl(i,j) + epsln))**l_smyth
-               langmuirfactor=sqrt(1+Cw_smyth*Ustk2(i,j)/(ustar(i,j)*ustar(i,j) + epsln))
-               langmuirfactor = max(1.0, langmuirfactor)
-               langmuirfactor = min(LTmax, langmuirfactor)
-               ws(i,j)=ws(i,j)*langmuirfactor
-               wm(i,j)=wm(i,j)*langmuirfactor
+!RASF      if (do_wave .and. do_langmuir) then
+      if (do_wave .or. do_langmuir) then
+         if ( do_langmuir_cvmix ) then
+            do j=jsc,jec
+               do i=isc,iec
+                  langmuir_number(i,j)= get_langmuir_number(ustar(i,j), hbl(i,j), Velocity%u10(i,j))
+                  langmuir_factor(i,j) = min(sqrt(1.0 + 1./1.5**2/langmuir_number(i,j)**2 + 1./(5.4**4)/langmuir_number(i,j)**4),LTmax)
+                  ws(i,j)=ws(i,j)*langmuir_factor(i,j)
+                  wm(i,j)=wm(i,j)*langmuir_factor(i,j)
+               enddo
             enddo
-         enddo
+
+         else
+            do j=jsc,jec
+               do i=isc,iec
+                  Cw_smyth=Cw_0*(ustar(i,j)*ustar(i,j)*ustar(i,j)/(ustar(i,j)*ustar(i,j)*ustar(i,j) &
+                       + Wstfac*von_karman*bfsfc(i,j)*hbl(i,j) + epsln))**l_smyth
+                  langmuir_factor(i,j)=sqrt(1+Cw_smyth*Ustk2(i,j)/(ustar(i,j)*ustar(i,j) + epsln))
+                  langmuir_factor(i,j) = max(1.0, langmuir_factor(i,j))
+                  langmuir_factor(i,j) = min(LTmax, langmuir_factor(i,j))
+                  ws(i,j)=ws(i,j)*langmuir_factor(i,j)
+                  wm(i,j)=wm(i,j)*langmuir_factor(i,j)
+               enddo
+            enddo
+         endif
       endif
 
 end subroutine wscale
@@ -2440,9 +2509,10 @@ end subroutine ddmix
 !
 ! </DESCRIPTION>
 !
-subroutine blmix_kpp(Thickness, diff_cbt, visc_cbu, do_wave)
+subroutine blmix_kpp(Thickness, Velocity, diff_cbt, visc_cbu, do_wave)
 
   type(ocean_thickness_type),     intent(in)    :: Thickness
+  type(ocean_Velocity_type),      intent(in)    :: Velocity
   real, dimension(isd:,jsd:,:,:), intent(inout) :: diff_cbt
   real, dimension(isd:,jsd:,:) ,  intent(inout) :: visc_cbu
   logical,                        intent(in)    :: do_wave
@@ -2469,7 +2539,7 @@ subroutine blmix_kpp(Thickness, diff_cbt, visc_cbu, do_wave)
         iwscale_use_hbl_eq_zt = 0
         zt_kl_dummy(:,:)      = 0.0
 
-        call wscale (iwscale_use_hbl_eq_zt, zt_kl_dummy, do_wave)
+        call wscale (iwscale_use_hbl_eq_zt, zt_kl_dummy, Velocity, do_wave)
 
       do j=jsc,jec
         do i = isc,iec 
@@ -2522,6 +2592,9 @@ subroutine blmix_kpp(Thickness, diff_cbt, visc_cbu, do_wave)
       enddo
 
       blmc(:,:,:,:) = 0.0
+      wrk1 = 0.0
+      wrk1_2d = 1.0
+      wrk2_2d = 0.0
 
       do ki=1,kbl_max !results are needed only for ki<kbl, hence, limiting this loops saves a lot of wscale calls
 
@@ -2540,7 +2613,7 @@ subroutine blmix_kpp(Thickness, diff_cbt, visc_cbu, do_wave)
           iwscale_use_hbl_eq_zt = 0
           zt_kl_dummy(:,:)      = 0.0
 
-          call wscale(iwscale_use_hbl_eq_zt, zt_kl_dummy, do_wave)
+          call wscale(iwscale_use_hbl_eq_zt, zt_kl_dummy, Velocity, do_wave)
 
 !-----------------------------------------------------------------------
 !         compute the dimensionless shape functions at the interfaces
@@ -2548,6 +2621,10 @@ subroutine blmix_kpp(Thickness, diff_cbt, visc_cbu, do_wave)
 !-----------------------------------------------------------------------
 
         if (id_ws > 0) wrk1(:,:,ki) =  ws(:,:)
+        if(ki == 1) then
+           if (id_lang_enh > 0) wrk1_2d =  langmuir_factor
+           if (id_lang > 0) wrk2_2d =  langmuir_number
+        endif
           
         do j=jsc,jec
           do i = isc,iec
@@ -2578,8 +2655,9 @@ subroutine blmix_kpp(Thickness, diff_cbt, visc_cbu, do_wave)
 !             nonlocal transport term = ghats * <ws>o (eqn. 20)
 !             To include Langmuir turbulence effects, multiply ghats
 !             by a factor of Lgam (McWilliam & Sullivan 2001)
+!             Do not do this if using cvmix version
 !-----------------------------------------------------------------------
-              if (do_wave .and. do_langmuir) then
+              if ((do_wave .or. do_langmuir) .and. .not. do_langmuir_cvmix) then
                  ghats(i,j,ki) = Lgam * (1.-stable(i,j)) * cg    &
                         / (ws(i,j) * hbl(i,j) + epsln)
               else
@@ -2608,7 +2686,7 @@ subroutine blmix_kpp(Thickness, diff_cbt, visc_cbu, do_wave)
       iwscale_use_hbl_eq_zt = 0
       zt_kl_dummy(:,:)      = 0.0
 
-      call wscale(iwscale_use_hbl_eq_zt, zt_kl_dummy, do_wave)
+      call wscale(iwscale_use_hbl_eq_zt, zt_kl_dummy, Velocity, do_wave)
 
       do j=jsc,jec
         do i = isc,iec
@@ -2827,7 +2905,137 @@ subroutine ri_for_kpp (Time, Thickness, aidif, Velocity, theta, salinity, &
 end subroutine ri_for_kpp
 ! </SUBROUTINE> NAME="ri_for_kpp"
 
+!#######################################################################
+!
+elemental real function ust_2_u10_coare3p5(USTair) result(u10)
+  real, intent(in) :: USTair
+  real, parameter :: nu=1e-6
+  real :: z0sm, z0, z0rough, u10a, alpha, CD
+  integer :: CT
 
+  ! Uses empirical formula for z0 to convert ustar_air to u10 based on the
+  !  COARE 3.5 paper (Edson et al., 2013)
+  !alpha=m*U10+b
+  !Note in Edson et al. 2013, eq. 13 m is given as 0.017.  However,
+  ! m=0.0017 reproduces the curve in their figure 6. Later acknowleged in
+  ! correction. RASF
+
+   z0sm = 0.11 * nu / USTair !Compute z0smooth from ustar guess
+   u10 = USTair/sqrt(0.001)  !Guess for u10
+   u10a = 1000
+
+   CT=0
+   do while (abs(u10a/u10-1.)>0.001)
+      CT=CT+1
+      u10a = u10
+      alpha = min(0.028,0.0017 * u10 - 0.005)
+      z0rough = alpha * USTair**2/grav ! Compute z0rough from ustar guess
+      z0=z0sm+z0rough
+      CD = ( von_karman / log(10/z0) )**2 ! Compute CD from derived roughness
+      u10 = USTair/sqrt(CD);!Compute new u10 from derived CD, while loop
+                       ! ends and checks for convergence...CT counter
+                       ! makes sure loop doesn't run away if function
+                       ! doesn't converge.  This code was produced offline
+                       ! and converged rapidly (e.g. 2 cycles)
+                       ! for ustar=0.0001:0.0001:10.
+      if (CT>20) then
+         u10 = USTair/sqrt(0.0015) ! I don't expect to get here, but just
+                              !  in case it will output a reasonable value.
+         exit
+      endif
+   enddo
+end function ust_2_u10_coare3p5
+
+
+real function get_langmuir_number(ustr, hbl, u10) result(LA)
+! Original description:
+! This function returns the Langmuir number, given the 10-meter
+! wind (m/s), friction velocity (m/s) and the boundary layer depth (m).
+! Update (Jan/25):
+!
+! Qing Li, 160606
+! BGR port from CVMix to MOM6 Jan/25/2017
+! Modified from MOM6 for MOM5 RASF 2018
+
+! Input
+  real, intent(in) :: &
+       ! water-side surface friction velocity (m/s)
+       ustr, &
+       ! boundary layer depth (m)
+       hbl, &
+       ! 10m winds (m/s)
+       u10
+!  real, intent(out) :: US_SL, LA
+!  real, intent(out) :: LA
+! Local variables
+  ! parameters
+  real, parameter :: &
+       ! ratio of U19.5 to U10 (Holthuijsen, 2007)
+       u19p5_to_u10 = 1.075, &
+       ! ratio of mean frequency to peak frequency for
+       ! Pierson-Moskowitz spectrum (Webb, 2011)
+       fm_to_fp = 1.296, &
+       ! ratio of surface Stokes drift to U10
+       us_to_u10 = 0.0162, &
+       ! loss ratio of Stokes transport
+       r_loss = 0.667
+  real :: us, us_sl, hm0, fm, fp, vstokes, kphil, kstar
+  real :: z0, z0i, r1, r2, r3, r4, tmp, lasl_sqr_i
+
+
+  if (ustr > 0.0 .and. u10 > 0.0) then
+    ! surface Stokes drift
+    us = us_to_u10*u10
+    !
+    ! significant wave height from Pierson-Moskowitz
+    ! spectrum (Bouws, 1998)
+    hm0 = 0.0246 *u10**2
+    !
+    ! peak frequency (PM, Bouws, 1998)
+    tmp = 2.0 * PI * u19p5_to_u10 * u10
+    fp = 0.877 * grav / tmp
+    !
+    ! mean frequency
+    fm = fm_to_fp * fp
+    !
+    ! total Stokes transport (a factor r_loss is applied to account
+    !  for the effect of directional spreading, multidirectional waves
+    !  and the use of PM peak frequency and PM significant wave height
+    !  on estimating the Stokes transport)
+    vstokes = 0.125 * PI * r_loss * fm * hm0**2
+    !
+    ! the general peak wavenumber for Phillips' spectrum
+    ! (Breivik et al., 2016) with correction of directional spreading
+    kphil = 0.176 * us / vstokes
+    !
+    ! surface layer averaged Stokes dirft with Stokes drift profile
+    ! estimated from Phillips' spectrum (Breivik et al., 2016)
+    ! the directional spreading effect from Webb and Fox-Kemper, 2015
+    ! is also included
+    kstar = kphil * 2.56
+    ! surface layer
+!RASF Dodgy as anything here. cvmix uses 0.2 but MOM6 looks like it uses 0.04 
+    z0 = 0.2*abs(hbl)
+    z0i = 1.0 / z0
+    ! term 1 to 4
+    r1 = ( 0.151 / kphil * z0i -0.84 ) &
+         * ( 1.0 - exp(-2.0 * kphil * z0) )
+    r2 = -( 0.84 + 0.0591 / kphil * z0i ) &
+         *sqrt( 2.0 * PI * kphil * z0 ) &
+         *erfc( sqrt( 2.0 * kphil * z0 ) )
+    r3 = ( 0.0632 / kstar * z0i + 0.125 ) &
+         * (1.0 - exp(-2.0 * kstar * z0) )
+    r4 = ( 0.125 + 0.0946 / kstar * z0i ) &
+         *sqrt( 2.0 * PI *kstar * z0) &
+         *erfc( sqrt( 2.0 * kstar * z0 ) )
+    us_sl = us * (0.715 + r1 + r2 + r3 + r4)
+    LA = sqrt(ustr/us_sl)
+  else
+    us_sl = 0.0
+    LA=1.e8
+  endif
+
+end function get_langmuir_number
 
 !#######################################################################
 ! <SUBROUTINE NAME="watermass_diag_init">

--- a/src/mom5/ocean_param/vertical/ocean_vert_mix.F90
+++ b/src/mom5/ocean_param/vertical/ocean_vert_mix.F90
@@ -2975,7 +2975,7 @@ subroutine vert_mix_coeff(Time, Thickness, Velocity, T_prog,   &
 
   type(ocean_time_type),          intent(in)    :: Time
   type(ocean_thickness_type),     intent(in)    :: Thickness
-  type(ocean_velocity_type),      intent(in)    :: Velocity
+  type(ocean_velocity_type),      intent(inout) :: Velocity
   type(ocean_prog_tracer_type),   intent(inout) :: T_prog(:)
   type(ocean_diag_tracer_type),   intent(in)    :: T_diag(:)
   type(ocean_density_type),       intent(in)    :: Dens


### PR DESCRIPTION
As per Russ' commits:

include Langmuir wave mixing (cvmix like) and diagnostics
allow 10m winds to be passed to model (incomplete but usable for standard mom, ok for access)
make aice allocatable and local to ocean_sbc module
enable calculation of u10 from ustar

This is a corrected version of the previous PR. Boring git details meant the previous commit contained spurious commits for the Jochum 2009 background diffusivity which had already been merged.