### PR TITLE
Fix bug on flux_z calculation for gm tracer flux diagnostics

### DIFF
--- a/src/mom5/ocean_param/neutral/ocean_nphysicsC.F90
+++ b/src/mom5/ocean_param/neutral/ocean_nphysicsC.F90
@@ -3722,7 +3722,7 @@ subroutine fz_flux_gm(T_prog, k)
 
       do n=1,num_prog_tracers
          fz2(n)%field(COMP)     = 0.0
-         flux_z(n)%field(:,:,:) = 0.0 ! for diagnostics only 
+         flux_z(n)%field(:,:,k) = 0.0 ! for diagnostics only 
       enddo
       return 
 


### PR DESCRIPTION
Fixes issue https://github.com/mom-ocean/MOM5/issues/227

I think this only affects the diagnostics temp_zflux_gm and salt_zflux_gm. Previous to this fix these were both outputting incorrectly as all zeros, now they appear to be outputting correctly (tested with ACCESS-OM2 1-degree runs).