### PR TITLE
Add travis CI for compilation checking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ env:
     
 matrix:
   allow_failures:
-    - env: MODEL=ACCESS-OM
-    - env: MODEL=ACCESS-CM
+    - env: TYPE=ACCESS-OM
+    - env: TYPE=ACCESS-CM
 
 install:
     - sudo apt-add-repository --yes ppa:ubuntu-toolchain-r/test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+# Travis doesn't have a fortran build config, so we'll use c as a base and
+# create our own environment
+language: c
+sudo: required
+
+env:
+    global:
+        - FC=gfortran-4.8
+        - OMPI_FC=${FC}
+install:
+    - sudo apt-add-repository --yes ppa:ubuntu-toolchain-r/test
+    - sudo apt-get update
+    - sudo apt-get install gcc-4.8 gfortran-4.8 libgomp1 openmpi-bin libopenmpi-dev  libnetcdf-dev  netcdf-bin
+
+script: 
+    - cd exp && ./MOM_compile.csh --type MOM_SIS --platform gfortran.openmpi --use_netcdf4
+
+
+# after_success:
+#     - find .
+#     - codecov --gcov-exec=gcov-4.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,15 @@ git:
     quiet: true
 
 env:
-    - MODEL=MOM_solo
-    - MODEL=MOM_SIS
-    - MODEL=CM2M
-    - MODEL=ESM2M
-    - MODEL=ICCM
-    - MODEL=EBM
-    - MODEL=ACCESS-OM
-    - MODEL=ACCESS-CM
+    matrix:
+        - MODEL=MOM_solo
+        - MODEL=MOM_SIS
+        - MODEL=CM2M
+        - MODEL=ESM2M
+        - MODEL=ICCM
+        - MODEL=EBM
+        - MODEL=ACCESS-OM
+        - MODEL=ACCESS-CM
     global:
         - FC=gfortran-4.8
         - OMPI_FC=${FC}

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,14 @@ git:
 
 env:
     matrix:
-        - MODEL=MOM_solo
-        - MODEL=MOM_SIS
-        - MODEL=CM2M
-        - MODEL=ESM2M
-        - MODEL=ICCM
-        - MODEL=EBM
-        - MODEL=ACCESS-OM
-        - MODEL=ACCESS-CM
+        - TYPE=MOM_solo
+        - TYPE=MOM_SIS
+        - TYPE=CM2M
+        - TYPE=ESM2M
+        - TYPE=ICCM
+        - TYPE=EBM
+        - TYPE=ACCESS-OM
+        - TYPE=ACCESS-CM
     global:
         - FC=gfortran-4.8
         - OMPI_FC=${FC}
@@ -29,10 +29,10 @@ matrix:
 install:
     - sudo apt-add-repository --yes ppa:ubuntu-toolchain-r/test
     - sudo apt-get update
-    - sudo apt-get install gcc-4.8 gfortran-4.8 libgomp1 openmpi-bin libopenmpi-dev  libnetcdf-dev  netcdf-bin
+    - sudo apt-get install csh gcc-4.8 gfortran-4.8 libgomp1 openmpi-bin libopenmpi-dev  libnetcdf-dev  netcdf-bin
 
 script: 
-    - cd exp && ./MOM_compile.csh --type MOM_SIS --platform travis --use_netcdf4
+    - cd exp && ./MOM_compile.csh --type $TYPE --platform travis --use_netcdf4
 
 # after_success:
 #     - find .

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,35 @@
 language: c
 sudo: required
 
+git:
+    depth: 3
+    quiet: true
+
 env:
+    - MODEL=MOM_solo
+    - MODEL=MOM_SIS
+    - MODEL=CM2M
+    - MODEL=ESM2M
+    - MODEL=ICCM
+    - MODEL=EBM
+    - MODEL=ACCESS-OM
+    - MODEL=ACCESS-CM
     global:
         - FC=gfortran-4.8
         - OMPI_FC=${FC}
+    
+matrix:
+  allow_failures:
+    - env: MODEL=ACCESS-OM
+    - env: MODEL=ACCESS-CM
+
 install:
     - sudo apt-add-repository --yes ppa:ubuntu-toolchain-r/test
     - sudo apt-get update
     - sudo apt-get install gcc-4.8 gfortran-4.8 libgomp1 openmpi-bin libopenmpi-dev  libnetcdf-dev  netcdf-bin
 
 script: 
-    - cd exp && ./MOM_compile.csh --type MOM_SIS --platform gfortran.openmpi --use_netcdf4
-
+    - cd exp && ./MOM_compile.csh --type MOM_SIS --platform travis --use_netcdf4
 
 # after_success:
 #     - find .

--- a/bin/environs.travis
+++ b/bin/environs.travis
@@ -1,0 +1,2 @@
+         setenv PATH ${PATH}:.
+         setenv mpirunCommand   "mpirun -np"

--- a/bin/mkmf.template.travis
+++ b/bin/mkmf.template.travis
@@ -1,0 +1,116 @@
+# $Id: gnu.mk,v 1.1.2.1.2.1 2012/03/07 15:08:54 sdu Exp $
+# template for the Intel fortran compiler
+# typical use with mkmf
+# mkmf -t template.ifc -c"-Duse_libMPI -Duse_netCDF" path_names /usr/local/include
+############
+# commands #
+############
+
+FC = mpif90
+CC = gcc
+LD = mpif90  $(MAIN_PROGRAM)
+
+#########
+# flags #
+#########
+
+MAKEFLAGS += --jobs=$(shell grep '^processor' /proc/cpuinfo | wc -l)
+
+FPPFLAGS := 
+
+FFLAGS := -O2 -fcray-pointer -fdefault-real-8 -ffree-line-length-none -fno-range-check -Waliasing -Wampersand -Warray-bounds -Wcharacter-truncation -Wconversion -Wline-truncation -Wintrinsics-std -Wsurprising -Wno-tabs -Wunderflow -Wintrinsic-shadow -Wno-align-commons -I/usr/include/openmpi -I/usr/include -DGFORTRAN
+
+CFLAGS := -D__IFC -O2 $(shell nc-config --cflags) -I/usr/include/openmpi
+
+LIBS := $(shell nc-config --flibs) -lpthread
+LDFLAGS += $(LIBS)
+
+#---------------------------------------------------------------------------
+# you should never need to change any lines below.
+
+# see the MIPSPro F90 manual for more details on some of the file extensions
+# discussed here.
+# this makefile template recognizes fortran sourcefiles with extensions
+# .f, .f90, .F, .F90. Given a sourcefile <file>.<ext>, where <ext> is one of
+# the above, this provides a number of default actions:
+
+# make <file>.opt	create an optimization report
+# make <file>.o		create an object file
+# make <file>.s		create an assembly listing
+# make <file>.x		create an executable file, assuming standalone
+#			source
+# make <file>.i		create a preprocessed file (for .F)
+# make <file>.i90	create a preprocessed file (for .F90)
+
+# The macro TMPFILES is provided to slate files like the above for removal.
+
+RM = rm -f
+SHELL = /bin/csh -f
+TMPFILES = .*.m *.B *.L *.i *.i90 *.l *.s *.mod *.opt
+
+.SUFFIXES: .F .F90 .H .L .T .f .f90 .h .i .i90 .l .o .s .opt .x
+
+.f.L:
+	$(FC) $(FFLAGS) -c -listing $*.f
+.f.opt:
+	$(FC) $(FFLAGS) -c -opt_report_level max -opt_report_phase all -opt_report_file $*.opt $*.f
+.f.l:
+	$(FC) $(FFLAGS) -c $(LIST) $*.f
+.f.T:
+	$(FC) $(FFLAGS) -c -cif $*.f
+.f.o:
+	$(FC) $(FFLAGS) -c $*.f
+.f.s:
+	$(FC) $(FFLAGS) -S $*.f
+.f.x:
+	$(FC) $(FFLAGS) -o $*.x $*.f *.o $(LDFLAGS)
+.f90.L:
+	$(FC) $(FFLAGS) -c -listing $*.f90
+.f90.opt:
+	$(FC) $(FFLAGS) -c -opt_report_level max -opt_report_phase all -opt_report_file $*.opt $*.f90
+.f90.l:
+	$(FC) $(FFLAGS) -c $(LIST) $*.f90
+.f90.T:
+	$(FC) $(FFLAGS) -c -cif $*.f90
+.f90.o:
+	$(FC) $(FFLAGS) -c $*.f90
+.f90.s:
+	$(FC) $(FFLAGS) -c -S $*.f90
+.f90.x:
+	$(FC) $(FFLAGS) -o $*.x $*.f90 *.o $(LDFLAGS)
+.F.L:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -listing $*.F
+.F.opt:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -opt_report_level max -opt_report_phase all -opt_report_file $*.opt $*.F
+.F.l:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c $(LIST) $*.F
+.F.T:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -cif $*.F
+.F.f:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) -EP $*.F > $*.f
+.F.i:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) -P $*.F
+.F.o:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c $*.F
+.F.s:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -S $*.F
+.F.x:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -o $*.x $*.F *.o $(LDFLAGS)
+.F90.L:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -listing $*.F90
+.F90.opt:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -opt_report_level max -opt_report_phase all -opt_report_file $*.opt $*.F90
+.F90.l:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c $(LIST) $*.F90
+.F90.T:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -cif $*.F90
+.F90.f90:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) -EP $*.F90 > $*.f90
+.F90.i90:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) -P $*.F90
+.F90.o:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c $*.F90
+.F90.s:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -S $*.F90
+.F90.x:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -o $*.x $*.F90 *.o $(LDFLAGS)


### PR DESCRIPTION
Add travis continuous integration (CI) which builds all known types.

Currently ACCESS-OM and ACCESS-CM are known failures due to external dependencies (OASIS)