### PR TITLE
Fix reds gulf bay timing fix, make time absolute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ src/shared/version/version.F90
 *.pyc
 tags
 data/archives
+src/shared/mpp/null_mpp_io_test.mod
+*.mod

--- a/src/accessom_coupler/ocean_solo.F90
+++ b/src/accessom_coupler/ocean_solo.F90
@@ -295,7 +295,7 @@ program main
   call get_time(Time_start,ss)
   ! The last sfix time has to be determined from absolute model time, to ensure reproducibility across
   ! restarts
-  Time_last_sfix = set_time(seconds=int(ss/(sfix_hours*SECONDS_PER_HOUR))*sfix_hours*SECONDS_PER_HOUR)
+  Time_last_sfix = set_time(seconds=int(int(ss/(sfix_hours*SECONDS_PER_HOUR))*sfix_hours*SECONDS_PER_HOUR))
   Time_sfix = set_time(seconds=int(sfix_hours*SECONDS_PER_HOUR))
 #endif
 

--- a/src/accessom_coupler/ocean_solo.F90
+++ b/src/accessom_coupler/ocean_solo.F90
@@ -292,7 +292,10 @@ program main
   num_cpld_calls    = Run_len / Time_step_coupled
   Time = Time_start
 #ifdef ACCESS
-  Time_last_sfix = Time_start
+  call get_time(Time_start,ss)
+  ! The last sfix time has to be determined from absolute model time, to ensure reproducibility across
+  ! restarts
+  Time_last_sfix = set_time(seconds=int(ss/(sfix_hours*SECONDS_PER_HOUR))*sfix_hours*SECONDS_PER_HOUR)
   Time_sfix = set_time(seconds=int(sfix_hours*SECONDS_PER_HOUR))
 #endif
 

--- a/src/accessom_coupler/ocean_solo.F90
+++ b/src/accessom_coupler/ocean_solo.F90
@@ -355,18 +355,10 @@ program main
   ! Get current model time from Time_init in seconds (must be done like this otherwise
   ! can get an overflow in seconds)
   call get_time(Time-Time_init,seconds)
-  if ( mpp_pe().EQ.mpp_root_pe() )then
-    print *,'Current model time in seconds = ',seconds
-    print *,'Current sfix_hours = ',sfix_hours
-  end if
   ! The last sfix time has to be determined from absolute model time, to ensure reproducibility 
   ! across restarts
   Time_last_sfix = set_time(seconds=int(seconds/sfix_seconds)*sfix_seconds) + Time_init
   Time_sfix = set_time(seconds=int(sfix_seconds))
-  if ( mpp_pe().EQ.mpp_root_pe() )then
-    call print_time(Time_last_sfix,'Time_last_sfix = ')
-    call print_time(Time_sfix,'Time_sfix = ')
-  end if
 #endif
 
   call data_override_init(Ocean_domain_in = Ocean_sfc%domain)
@@ -436,8 +428,6 @@ program main
      endif
 
 #ifdef ACCESS
-     call print_time(Time - Time_last_sfix,'Time - Time_last_sfix = ')
-     call print_time(Time_sfix,'Time_sfix = ')
      if ((Time - Time_last_sfix) >= Time_sfix) then
         do_sfix_now = .true.
         Time_last_sfix = Time

--- a/src/accessom_coupler/ocean_solo.F90
+++ b/src/accessom_coupler/ocean_solo.F90
@@ -435,6 +435,8 @@ program main
         do_sfix_now = .true.
         Time_last_sfix = Time
      else
+        call print_time(Time - Time_last_sfix,'Time - Time_last_sfix = ')
+        call print_time(Time_sfix,'Time_sfix = ')
         do_sfix_now = .false.
      end if
 #endif

--- a/src/accessom_coupler/ocean_solo.F90
+++ b/src/accessom_coupler/ocean_solo.F90
@@ -298,7 +298,7 @@ program main
   end if
   ! The last sfix time has to be determined from absolute model time, to ensure reproducibility across
   ! restarts
-  Time_last_sfix = set_time(seconds=seconds-mod(seconds,sfix_hours*SECONDS_PER_HOUR))
+  Time_last_sfix = set_time(seconds=seconds-mod(seconds,int(sfix_hours*SECONDS_PER_HOUR))
   Time_sfix = set_time(seconds=int(sfix_hours*SECONDS_PER_HOUR))
   if ( mpp_pe().EQ.mpp_root_pe() )then
     call print_time(Time_last_sfix,'Time_last_sfix = ')

--- a/src/accessom_coupler/ocean_solo.F90
+++ b/src/accessom_coupler/ocean_solo.F90
@@ -350,16 +350,18 @@ program main
                         accessom2%get_ice_ocean_timestep())
 
 #ifdef ACCESS
-  ! This must be called after ocean_model_init so sfix_hours can be read
+  ! This must be called after ocean_model_init so sfix_hours is read in from namelist
   sfix_seconds = sfix_hours * SECONDS_PER_HOUR
+  ! Get current model time from Time_init in seconds (must be done like this otherwise
+  ! can get an overflow in seconds)
   call get_time(Time-Time_init,seconds)
   if ( mpp_pe().EQ.mpp_root_pe() )then
     print *,'Current model time in seconds = ',seconds
     print *,'Current sfix_hours = ',sfix_hours
   end if
-  ! The last sfix time has to be determined from absolute model time, to ensure reproducibility across
-  ! restarts
-  Time_last_sfix = set_time(seconds=seconds-(int(seconds/sfix_seconds)*sfix_seconds)) + Time_init
+  ! The last sfix time has to be determined from absolute model time, to ensure reproducibility 
+  ! across restarts
+  Time_last_sfix = set_time(seconds=nint(int(seconds/sfix_seconds)*sfix_seconds)) + Time_init
   Time_sfix = set_time(seconds=int(sfix_seconds))
   if ( mpp_pe().EQ.mpp_root_pe() )then
     call print_time(Time_last_sfix,'Time_last_sfix = ')

--- a/src/accessom_coupler/ocean_solo.F90
+++ b/src/accessom_coupler/ocean_solo.F90
@@ -172,6 +172,8 @@ program main
   character(len=1024) :: accessom2_config_dir = '../'
   integer, dimension(6) :: date_array
 
+  integer :: sfix_seconds
+
   namelist /ocean_solo_nml/ n_mask, layout_mask, mask_list, restart_interval, &
                             debug_this_module, accessom2_config_dir
 
@@ -349,6 +351,7 @@ program main
 
 #ifdef ACCESS
   ! This must be called after ocean_model_init so sfix_hours can be read
+  sfix_seconds = sfix_hours * SECONDS_PER_HOUR
   call get_time(Time_start-Time_init,seconds)
   if ( mpp_pe().EQ.mpp_root_pe() )then
     print *,'Current model time in seconds = ',seconds
@@ -356,7 +359,7 @@ program main
   end if
   ! The last sfix time has to be determined from absolute model time, to ensure reproducibility across
   ! restarts
-  Time_last_sfix = set_time(seconds=seconds-mod(seconds,int(sfix_hours*SECONDS_PER_HOUR)))
+  Time_last_sfix = set_time(seconds=seconds-(int(seconds/sfix_seconds)*sfix_seconds))
   Time_sfix = set_time(seconds=int(sfix_hours*SECONDS_PER_HOUR))
   if ( mpp_pe().EQ.mpp_root_pe() )then
     call print_time(Time_last_sfix,'Time_last_sfix = ')

--- a/src/accessom_coupler/ocean_solo.F90
+++ b/src/accessom_coupler/ocean_solo.F90
@@ -292,14 +292,13 @@ program main
   num_cpld_calls    = Run_len / Time_step_coupled
   Time = Time_start
 #ifdef ACCESS
-  call get_time(Time_start,seconds,days)
+  call get_time(Time_start-Time_init,seconds)
   if ( mpp_pe().EQ.mpp_root_pe() )then
-    print *,'days = ',days
-    print *,'seconds = ',seconds
+    print *,'Current model time in seconds = ',seconds
   end if
   ! The last sfix time has to be determined from absolute model time, to ensure reproducibility across
   ! restarts
-  Time_last_sfix = set_time(seconds=int(int(seconds/(sfix_hours*SECONDS_PER_HOUR))*sfix_hours*SECONDS_PER_HOUR))
+  Time_last_sfix = set_time(seconds=seconds-mod(seconds,sfix_hours*SECONDS_PER_HOUR))
   Time_sfix = set_time(seconds=int(sfix_hours*SECONDS_PER_HOUR))
   if ( mpp_pe().EQ.mpp_root_pe() )then
     call print_time(Time_last_sfix,'Time_last_sfix = ')

--- a/src/accessom_coupler/ocean_solo.F90
+++ b/src/accessom_coupler/ocean_solo.F90
@@ -292,13 +292,16 @@ program main
   num_cpld_calls    = Run_len / Time_step_coupled
   Time = Time_start
 #ifdef ACCESS
-  call get_time(Time_start,ss)
+  call get_time(Time_start,seconds,days)
+  if ( mpp_pe().EQ.mpp_root_pe() )then
+    print *,'days = ',days
+    print *,'seconds = ',seconds
+  end if
   ! The last sfix time has to be determined from absolute model time, to ensure reproducibility across
   ! restarts
-  Time_last_sfix = set_time(seconds=int(int(ss/(sfix_hours*SECONDS_PER_HOUR))*sfix_hours*SECONDS_PER_HOUR))
+  Time_last_sfix = set_time(seconds=int(int(seconds/(sfix_hours*SECONDS_PER_HOUR))*sfix_hours*SECONDS_PER_HOUR))
   Time_sfix = set_time(seconds=int(sfix_hours*SECONDS_PER_HOUR))
   if ( mpp_pe().EQ.mpp_root_pe() )then
-    print *,'ss = ',ss
     call print_time(Time_last_sfix,'Time_last_sfix = ')
     call print_time(Time_sfix,'Time_sfix = ')
   end if

--- a/src/accessom_coupler/ocean_solo.F90
+++ b/src/accessom_coupler/ocean_solo.F90
@@ -352,7 +352,7 @@ program main
   call get_time(Time_start-Time_init,seconds)
   if ( mpp_pe().EQ.mpp_root_pe() )then
     print *,'Current model time in seconds = ',seconds
-    print *,'Current sfix_hours = ',sifx_hours
+    print *,'Current sfix_hours = ',sfix_hours
   end if
   ! The last sfix time has to be determined from absolute model time, to ensure reproducibility across
   ! restarts

--- a/src/accessom_coupler/ocean_solo.F90
+++ b/src/accessom_coupler/ocean_solo.F90
@@ -352,6 +352,7 @@ program main
   call get_time(Time_start-Time_init,seconds)
   if ( mpp_pe().EQ.mpp_root_pe() )then
     print *,'Current model time in seconds = ',seconds
+    print *,'Current sfix_hours = ',sifx_hours
   end if
   ! The last sfix time has to be determined from absolute model time, to ensure reproducibility across
   ! restarts

--- a/src/accessom_coupler/ocean_solo.F90
+++ b/src/accessom_coupler/ocean_solo.F90
@@ -297,6 +297,9 @@ program main
   ! restarts
   Time_last_sfix = set_time(seconds=int(int(ss/(sfix_hours*SECONDS_PER_HOUR))*sfix_hours*SECONDS_PER_HOUR))
   Time_sfix = set_time(seconds=int(sfix_hours*SECONDS_PER_HOUR))
+  if ( mpp_pe().EQ.mpp_root_pe() )then
+    print *,'ss = ',ss,'Time_last_sfix = ',Time_last_sfix ,'Time_sfix = ',Time_sfix 
+  end if
 #endif
 
   Time_restart_init = set_date(date_restart(1), date_restart(2), date_restart(3),  &

--- a/src/accessom_coupler/ocean_solo.F90
+++ b/src/accessom_coupler/ocean_solo.F90
@@ -298,7 +298,7 @@ program main
   end if
   ! The last sfix time has to be determined from absolute model time, to ensure reproducibility across
   ! restarts
-  Time_last_sfix = set_time(seconds=seconds-mod(seconds,int(sfix_hours*SECONDS_PER_HOUR))
+  Time_last_sfix = set_time(seconds=seconds-mod(seconds,int(sfix_hours*SECONDS_PER_HOUR)))
   Time_sfix = set_time(seconds=int(sfix_hours*SECONDS_PER_HOUR))
   if ( mpp_pe().EQ.mpp_root_pe() )then
     call print_time(Time_last_sfix,'Time_last_sfix = ')

--- a/src/accessom_coupler/ocean_solo.F90
+++ b/src/accessom_coupler/ocean_solo.F90
@@ -133,6 +133,7 @@ program main
 #ifdef ACCESS
   type(time_type) :: Time_last_sfix 
   type(time_type) :: Time_sfix 
+  integer :: sfix_seconds
 #endif
 
   character(len=17) :: calendar = 'julian'
@@ -171,8 +172,6 @@ program main
   logical :: debug_this_module
   character(len=1024) :: accessom2_config_dir = '../'
   integer, dimension(6) :: date_array
-
-  integer :: sfix_seconds
 
   namelist /ocean_solo_nml/ n_mask, layout_mask, mask_list, restart_interval, &
                             debug_this_module, accessom2_config_dir

--- a/src/accessom_coupler/ocean_solo.F90
+++ b/src/accessom_coupler/ocean_solo.F90
@@ -352,7 +352,7 @@ program main
 #ifdef ACCESS
   ! This must be called after ocean_model_init so sfix_hours can be read
   sfix_seconds = sfix_hours * SECONDS_PER_HOUR
-  call get_time(Time_start-Time_init,seconds)
+  call get_time(Time-Time_init,seconds)
   if ( mpp_pe().EQ.mpp_root_pe() )then
     print *,'Current model time in seconds = ',seconds
     print *,'Current sfix_hours = ',sfix_hours
@@ -434,12 +434,12 @@ program main
      endif
 
 #ifdef ACCESS
+     call print_time(Time - Time_last_sfix,'Time - Time_last_sfix = ')
+     call print_time(Time_sfix,'Time_sfix = ')
      if ((Time - Time_last_sfix) >= Time_sfix) then
         do_sfix_now = .true.
         Time_last_sfix = Time
      else
-        call print_time(Time - Time_last_sfix,'Time - Time_last_sfix = ')
-        call print_time(Time_sfix,'Time_sfix = ')
         do_sfix_now = .false.
      end if
 #endif

--- a/src/accessom_coupler/ocean_solo.F90
+++ b/src/accessom_coupler/ocean_solo.F90
@@ -359,8 +359,8 @@ program main
   end if
   ! The last sfix time has to be determined from absolute model time, to ensure reproducibility across
   ! restarts
-  Time_last_sfix = set_time(seconds=seconds-(int(seconds/sfix_seconds)*sfix_seconds))
-  Time_sfix = set_time(seconds=int(sfix_hours*SECONDS_PER_HOUR))
+  Time_last_sfix = set_time(seconds=seconds-(int(seconds/sfix_seconds)*sfix_seconds)) + Time_init
+  Time_sfix = set_time(seconds=int(sfix_seconds))
   if ( mpp_pe().EQ.mpp_root_pe() )then
     call print_time(Time_last_sfix,'Time_last_sfix = ')
     call print_time(Time_sfix,'Time_sfix = ')

--- a/src/accessom_coupler/ocean_solo.F90
+++ b/src/accessom_coupler/ocean_solo.F90
@@ -361,7 +361,7 @@ program main
   end if
   ! The last sfix time has to be determined from absolute model time, to ensure reproducibility 
   ! across restarts
-  Time_last_sfix = set_time(seconds=int(int(seconds/sfix_seconds)*sfix_seconds)) + Time_init
+  Time_last_sfix = set_time(seconds=int(seconds/sfix_seconds)*sfix_seconds) + Time_init
   Time_sfix = set_time(seconds=int(sfix_seconds))
   if ( mpp_pe().EQ.mpp_root_pe() )then
     call print_time(Time_last_sfix,'Time_last_sfix = ')

--- a/src/accessom_coupler/ocean_solo.F90
+++ b/src/accessom_coupler/ocean_solo.F90
@@ -94,7 +94,7 @@ program main
   use mpp_mod,                  only: mpp_broadcast
   use time_interp_external_mod, only: time_interp_external_init
   use time_manager_mod,         only: set_calendar_type, time_type, increment_date
-  use time_manager_mod,         only: set_time, set_date, get_time, get_date, month_name
+  use time_manager_mod,         only: set_time, set_date, get_time, get_date, month_name, print_time
   use time_manager_mod,         only: GREGORIAN, JULIAN, NOLEAP, THIRTY_DAY_MONTHS, NO_CALENDAR
   use time_manager_mod,         only: operator( <= ), operator( < ), operator( >= )
   use time_manager_mod,         only: operator( + ),  operator( - ), operator( / )

--- a/src/accessom_coupler/ocean_solo.F90
+++ b/src/accessom_coupler/ocean_solo.F90
@@ -291,20 +291,6 @@ program main
   Time_step_coupled = set_time(dt_cpld, 0)
   num_cpld_calls    = Run_len / Time_step_coupled
   Time = Time_start
-#ifdef ACCESS
-  call get_time(Time_start-Time_init,seconds)
-  if ( mpp_pe().EQ.mpp_root_pe() )then
-    print *,'Current model time in seconds = ',seconds
-  end if
-  ! The last sfix time has to be determined from absolute model time, to ensure reproducibility across
-  ! restarts
-  Time_last_sfix = set_time(seconds=seconds-mod(seconds,int(sfix_hours*SECONDS_PER_HOUR)))
-  Time_sfix = set_time(seconds=int(sfix_hours*SECONDS_PER_HOUR))
-  if ( mpp_pe().EQ.mpp_root_pe() )then
-    call print_time(Time_last_sfix,'Time_last_sfix = ')
-    call print_time(Time_sfix,'Time_sfix = ')
-  end if
-#endif
 
   Time_restart_init = set_date(date_restart(1), date_restart(2), date_restart(3),  &
                                date_restart(4), date_restart(5), date_restart(6) )
@@ -360,6 +346,22 @@ program main
 
   call ocean_model_init(Ocean_sfc, Ocean_state, Time_init, Time, &
                         accessom2%get_ice_ocean_timestep())
+
+#ifdef ACCESS
+  ! This must be called after ocean_model_init so sfix_hours can be read
+  call get_time(Time_start-Time_init,seconds)
+  if ( mpp_pe().EQ.mpp_root_pe() )then
+    print *,'Current model time in seconds = ',seconds
+  end if
+  ! The last sfix time has to be determined from absolute model time, to ensure reproducibility across
+  ! restarts
+  Time_last_sfix = set_time(seconds=seconds-mod(seconds,int(sfix_hours*SECONDS_PER_HOUR)))
+  Time_sfix = set_time(seconds=int(sfix_hours*SECONDS_PER_HOUR))
+  if ( mpp_pe().EQ.mpp_root_pe() )then
+    call print_time(Time_last_sfix,'Time_last_sfix = ')
+    call print_time(Time_sfix,'Time_sfix = ')
+  end if
+#endif
 
   call data_override_init(Ocean_domain_in = Ocean_sfc%domain)
 

--- a/src/accessom_coupler/ocean_solo.F90
+++ b/src/accessom_coupler/ocean_solo.F90
@@ -361,7 +361,7 @@ program main
   end if
   ! The last sfix time has to be determined from absolute model time, to ensure reproducibility 
   ! across restarts
-  Time_last_sfix = set_time(seconds=nint(int(seconds/sfix_seconds)*sfix_seconds)) + Time_init
+  Time_last_sfix = set_time(seconds=int(int(seconds/sfix_seconds)*sfix_seconds)) + Time_init
   Time_sfix = set_time(seconds=int(sfix_seconds))
   if ( mpp_pe().EQ.mpp_root_pe() )then
     call print_time(Time_last_sfix,'Time_last_sfix = ')

--- a/src/accessom_coupler/ocean_solo.F90
+++ b/src/accessom_coupler/ocean_solo.F90
@@ -298,7 +298,9 @@ program main
   Time_last_sfix = set_time(seconds=int(int(ss/(sfix_hours*SECONDS_PER_HOUR))*sfix_hours*SECONDS_PER_HOUR))
   Time_sfix = set_time(seconds=int(sfix_hours*SECONDS_PER_HOUR))
   if ( mpp_pe().EQ.mpp_root_pe() )then
-    print *,'ss = ',ss,'Time_last_sfix = ',Time_last_sfix ,'Time_sfix = ',Time_sfix 
+    print *,'ss = ',ss
+    call print_time(Time_last_sfix,'Time_last_sfix = ')
+    call print_time(Time_sfix,'Time_sfix = ')
   end if
 #endif
 


### PR DESCRIPTION
The previous fix for the reds gulf bay timing fix (https://github.com/mom-ocean/MOM5/pull/215) didn't use absolute model time, so might not reproduce correctly.

This has been fixed and verified that timing for 2x2 month run are the same as 4x1 month run.

There was also an unnoticed bug that the initialisation of the timing was before the namelist had been read which allowed sfix_hours to be set.