### PR TITLE
Fix time overflow issue with redsea gulf bay timing "fix"

### DIFF
--- a/src/accesscm_coupler/ocean_solo.F90
+++ b/src/accesscm_coupler/ocean_solo.F90
@@ -140,7 +140,7 @@ program main
   use mpp_mod,                  only: MPP_CLOCK_DETAILED, CLOCK_COMPONENT, MAXPES
   use time_interp_external_mod, only: time_interp_external_init
   use time_manager_mod,         only: set_calendar_type, time_type, increment_date
-  use time_manager_mod,         only: set_time, set_date, get_time, get_date, month_name
+  use time_manager_mod,         only: set_time, set_date, get_time, get_date, month_name, print_time
   use time_manager_mod,         only: GREGORIAN, JULIAN, NOLEAP, THIRTY_DAY_MONTHS, NO_CALENDAR
   use time_manager_mod,         only: operator( <= ), operator( < ), operator( >= )
   use time_manager_mod,         only: operator( + ),  operator( - ), operator( / )

--- a/src/accessom_coupler/ocean_solo.F90
+++ b/src/accessom_coupler/ocean_solo.F90
@@ -368,7 +368,7 @@ program main
     days = hours / 24
     hours = hours - days*24
 
-    Time_last_sfix = set_time(days=days,seconds=hours*SECONDS_PER_HOUR) + Time_init
+    Time_last_sfix = set_time(days=int(days),seconds=int(hours*SECONDS_PER_HOUR) + Time_init
     Time_sfix = set_time(seconds=int(sfix_seconds))
   end if
 #endif

--- a/src/accessom_coupler/ocean_solo.F90
+++ b/src/accessom_coupler/ocean_solo.F90
@@ -361,6 +361,12 @@ program main
     ! Current time to nearest hour
     hours = days*24 + int(seconds/SECONDS_PER_HOUR)
 
+    if ( mpp_pe() == mpp_root_pe() ) then
+        print *,'days ',days
+        print *,'hours ',hours
+        print *,'hours (int)',hours = int(hours / sfix_hours) * sfix_hours
+    end if
+
     ! Time of last sfix 
     hours = int(hours / sfix_hours) * sfix_hours
 

--- a/src/accessom_coupler/ocean_solo.F90
+++ b/src/accessom_coupler/ocean_solo.F90
@@ -367,6 +367,10 @@ program main
     ! Convert to days + hours
     days = int(hours / 24)
     hours = hours - days*24
+    if ( mpp_pe() == mpp_root_pe() ) then
+        print *,'days ',days
+        print *,'hours ',hours
+    end if
 
     Time_last_sfix = set_time(days=int(days),seconds=int(hours*SECONDS_PER_HOUR)) + Time_init
     Time_sfix = set_time(seconds=int(sfix_seconds))

--- a/src/accessom_coupler/ocean_solo.F90
+++ b/src/accessom_coupler/ocean_solo.F90
@@ -365,11 +365,14 @@ program main
     hours = int(hours / sfix_hours) * sfix_hours
 
     ! Convert to days + hours
-    days = hours / 24
+    days = int(hours / 24)
     hours = hours - days*24
 
     Time_last_sfix = set_time(days=int(days),seconds=int(hours*SECONDS_PER_HOUR)) + Time_init
     Time_sfix = set_time(seconds=int(sfix_seconds))
+    call print_time(Time,'Time: ')
+    call print_time(Time_init,'Time_init: ')
+    call print_time(Time_last_sfix,'Time_last_sfix: ')
   end if
 #endif
 

--- a/src/accessom_coupler/ocean_solo.F90
+++ b/src/accessom_coupler/ocean_solo.F90
@@ -349,15 +349,28 @@ program main
                         accessom2%get_ice_ocean_timestep())
 
 #ifdef ACCESS
-  ! This must be called after ocean_model_init so sfix_hours is read in from namelist
-  sfix_seconds = sfix_hours * SECONDS_PER_HOUR
-  ! Get current model time from Time_init in seconds (must be done like this otherwise
-  ! can get an overflow in seconds)
-  call get_time(Time-Time_init,seconds)
-  ! The last sfix time has to be determined from absolute model time, to ensure reproducibility 
-  ! across restarts
-  Time_last_sfix = set_time(seconds=int(seconds/sfix_seconds)*sfix_seconds) + Time_init
-  Time_sfix = set_time(seconds=int(sfix_seconds))
+  if (redsea_gulfbay_sfix) then
+    ! This must be called after ocean_model_init so sfix_hours is read in from namelist
+    sfix_seconds = sfix_hours * SECONDS_PER_HOUR
+    ! Get current model time from Time_init in seconds (must be done like this otherwise
+    ! can get an overflow in seconds)
+    call get_time(Time-Time_init,days,seconds)
+    ! The last sfix time has to be determined from absolute model time, to ensure reproducibility 
+    ! across restarts
+
+    ! Current time to nearest hour
+    hours = days*24 + int(seconds/SECONDS_PER_HOUR)
+
+    ! Time of last sfix 
+    hours = int(hours / sfix_hours) * sfix_hours
+
+    ! Convert to days + hours
+    days = hours / 24
+    hours = hours - days*24
+
+    Time_last_sfix = set_time(days=days,seconds=hours*SECONDS_PER_HOUR) + Time_init
+    Time_sfix = set_time(seconds=int(sfix_seconds))
+  end if
 #endif
 
   call data_override_init(Ocean_domain_in = Ocean_sfc%domain)
@@ -427,12 +440,14 @@ program main
      endif
 
 #ifdef ACCESS
-     if ((Time - Time_last_sfix) >= Time_sfix) then
-        do_sfix_now = .true.
-        Time_last_sfix = Time
-     else
-        do_sfix_now = .false.
-     end if
+    if (redsea_gulfbay_sfix) then
+        if ((Time - Time_last_sfix) >= Time_sfix) then
+            do_sfix_now = .true.
+            Time_last_sfix = Time
+        else
+            do_sfix_now = .false.
+        end if
+    end if
 #endif
 
      call update_ocean_model(Ice_ocean_boundary, Ocean_state, Ocean_sfc, Time, Time_step_coupled)

--- a/src/accessom_coupler/ocean_solo.F90
+++ b/src/accessom_coupler/ocean_solo.F90
@@ -354,7 +354,7 @@ program main
     sfix_seconds = sfix_hours * SECONDS_PER_HOUR
     ! Get current model time from Time_init in seconds (must be done like this otherwise
     ! can get an overflow in seconds)
-    call get_time(Time-Time_init,days,seconds)
+    call get_time(Time-Time_init,seconds=seconds,days=days)
     ! The last sfix time has to be determined from absolute model time, to ensure reproducibility 
     ! across restarts
 

--- a/src/accessom_coupler/ocean_solo.F90
+++ b/src/accessom_coupler/ocean_solo.F90
@@ -364,7 +364,7 @@ program main
     if ( mpp_pe() == mpp_root_pe() ) then
         print *,'days ',days
         print *,'hours ',hours
-        print *,'hours (int)',hours = int(hours / sfix_hours) * sfix_hours
+        print *,'hours (int)',int(hours / sfix_hours) * sfix_hours
     end if
 
     ! Time of last sfix 

--- a/src/accessom_coupler/ocean_solo.F90
+++ b/src/accessom_coupler/ocean_solo.F90
@@ -361,27 +361,16 @@ program main
     ! Current time to nearest hour
     hours = days*24 + int(seconds/SECONDS_PER_HOUR)
 
-    if ( mpp_pe() == mpp_root_pe() ) then
-        print *,'days ',days
-        print *,'hours ',hours
-        print *,'hours (int)',int(hours / sfix_hours) * sfix_hours
-    end if
-
     ! Time of last sfix 
     hours = int(hours / sfix_hours) * sfix_hours
 
     ! Convert to days + hours
     days = int(hours / 24)
     hours = hours - days*24
-    if ( mpp_pe() == mpp_root_pe() ) then
-        print *,'days ',days
-        print *,'hours ',hours
-    end if
 
     Time_last_sfix = set_time(days=int(days),seconds=int(hours*SECONDS_PER_HOUR)) + Time_init
     Time_sfix = set_time(seconds=int(sfix_seconds))
-    call print_time(Time,'Time: ')
-    call print_time(Time_init,'Time_init: ')
+
     call print_time(Time_last_sfix,'Time_last_sfix: ')
   end if
 #endif

--- a/src/accessom_coupler/ocean_solo.F90
+++ b/src/accessom_coupler/ocean_solo.F90
@@ -368,7 +368,7 @@ program main
     days = hours / 24
     hours = hours - days*24
 
-    Time_last_sfix = set_time(days=int(days),seconds=int(hours*SECONDS_PER_HOUR) + Time_init
+    Time_last_sfix = set_time(days=int(days),seconds=int(hours*SECONDS_PER_HOUR)) + Time_init
     Time_sfix = set_time(seconds=int(sfix_seconds))
   end if
 #endif


### PR DESCRIPTION
I fixed the redsea gulf bay timing fix, but this lead to an overflow in the seconds field when calling `get-time`.

This code uses day and seconds and performs calculations in hours (which is the unit that fix is defined in). 

Tested that it works as designed, but have not tested the overflow condition.