### PR TITLE
Fix smoothing of hblt and eliminate unessary domain updates

### DIFF
--- a/src/mom5/ocean_diag/ocean_adv_vel_diag.F90
+++ b/src/mom5/ocean_diag/ocean_adv_vel_diag.F90
@@ -1019,7 +1019,7 @@ subroutine transport_on_nrho (Time, Dens, Adv_vel)
             do j=jsc,jec
                do i=isc,iec
                   if (k_rho == 1) then
-                     if(Dens%neutralrho(i,j,k) < Dens%neutralrho_bounds(k_rho+1)) then
+                     if(Dens%neutralrho(i,j,k) < Dens%neutralrho_bounds(k_rho)) then 
                          tmp(1,i,j) = tmp(1,i,j) + Adv_vel%uhrho_et(i,j,k)
                          tmp(2,i,j) = tmp(2,i,j) + Adv_vel%vhrho_nt(i,j,k)
                      endif
@@ -1030,7 +1030,7 @@ subroutine transport_on_nrho (Time, Dens, Adv_vel)
                            tmp(2,i,j) = tmp(2,i,j) + Adv_vel%vhrho_nt(i,j,k)
                      endif
                   else    ! if (k_rho == neutralrho_nk) then
-                     if(Dens%neutralrho_bounds(k_rho) <= Dens%neutralrho(i,j,k)) then
+                     if(Dens%neutralrho_bounds(k_rho) <= Dens%neutralrho(i,j,k)) then 
                          tmp(1,i,j) = tmp(1,i,j) + Adv_vel%uhrho_et(i,j,k)             
                          tmp(2,i,j) = tmp(2,i,j) + Adv_vel%vhrho_nt(i,j,k)
                      endif
@@ -1127,7 +1127,7 @@ subroutine transport_on_rho (Time, Dens, Adv_vel)
             do j=jsc,jec
                do i=isc,iec
                   if (k_rho == 1) then 
-                     if(Dens%potrho(i,j,k) < Dens%potrho_bounds(k_rho+1)) then
+                     if(Dens%potrho(i,j,k) < Dens%potrho_bounds(k_rho)) then 
                         tmp(1,i,j) = tmp(1,i,j) + Adv_vel%uhrho_et(i,j,k)
                         tmp(2,i,j) = tmp(2,i,j) + Adv_vel%vhrho_nt(i,j,k)
                      endif
@@ -1236,7 +1236,7 @@ subroutine transport_on_theta (Time, Dens, Theta, Adv_vel)
             do j=jsc,jec
                do i=isc,iec
                   if (k_theta == 1) then
-                     if(Theta%field(i,j,k,tau) < Dens%theta_bounds(k_theta+1)) then
+                     if(Theta%field(i,j,k,tau) < Dens%theta_bounds(k_theta)) then 
                          tmp(1,i,j) = tmp(1,i,j) + Adv_vel%uhrho_et(i,j,k)
                          tmp(2,i,j) = tmp(2,i,j) + Adv_vel%vhrho_nt(i,j,k)
                      endif

--- a/src/mom5/ocean_diag/ocean_tracer_util.F90
+++ b/src/mom5/ocean_diag/ocean_tracer_util.F90
@@ -820,7 +820,7 @@ subroutine rebin_onto_rho (rho_bounds, rho_level, infield_level, outfield_rho)
 
                   ! light waters 
                   if (k_rho == 1) then
-                      if(rho_level(i,j,k) < rho_bounds(k_rho)+1) then
+                      if(rho_level(i,j,k) < rho_bounds(k_rho)) then 
                           outfield_rho(i,j,k_rho) = outfield_rho(i,j,k_rho) + infield_level(i,j,k)
                       endif
 


### PR DESCRIPTION
Horizontal smoothing could force `hblt` to be deeper than column depth. Enforce a limit.
Spurious masking of smoothed `hblt` to the North removed.
Eliminated some redundant domain updates. 

https://github.com/mom-ocean/MOM5/issues/264