### PR TITLE
Fix CF Names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,7 @@ install:
     - sudo apt-get install csh gcc-4.8 gfortran-4.8 libgomp1 openmpi-bin libopenmpi-dev  libnetcdf-dev  netcdf-bin
 
 before_script:
-    - git clone --depth=1 https://github.com/OceansAus/oasis3-mct.git
-    - (cd oasis3-mct && make ubuntu)
+    - [[ $TYPE =~ (^ACCESS) ]] && git clone --depth=1 https://github.com/OceansAus/oasis3-mct.git && (cd oasis3-mct && make ubuntu)
 
 script: 
     - cd exp && ./MOM_compile.csh --type $TYPE --platform travis --use_netcdf4

--- a/src/mom5/ocean_diag/ocean_adv_vel_diag.F90
+++ b/src/mom5/ocean_diag/ocean_adv_vel_diag.F90
@@ -231,11 +231,11 @@ endif
 id_tx_trans = register_diag_field ('ocean_model','tx_trans', Grd%tracer_axes_flux_x(1:3),&
               Time%model_time, 'T-cell i-mass transport',trim(transport_dims),           &
               missing_value=missing_value, range=(/-1e20,1e20/),                         &
-              standard_name='ocean_x_mass_transport')
+              standard_name='ocean_mass_x_transport')
 id_ty_trans = register_diag_field ('ocean_model','ty_trans', Grd%tracer_axes_flux_y(1:3), &
               Time%model_time, 'T-cell j-mass transport',trim(transport_dims),            &
               missing_value=missing_value, range=(/-1e20,1e20/),                          &
-              standard_name='ocean_y_mass_transport')
+              standard_name='ocean_mass_y_transport')
 id_tx_trans_int_z = register_diag_field ('ocean_model','tx_trans_int_z',        &
               Grd%tracer_axes_flux_x(1:2), Time%model_time,                     &
               'T-cell i-mass transport vertically summed',trim(transport_dims), &


### PR DESCRIPTION
Fixes https://github.com/mom-ocean/MOM5/issues/287

Fixed two incorrect CF standard_names:

```
ocean_x_mass_transport -> ocean_mass_x_transport
ocean_y_mass_transport -> ocean_mass_y_transport
```