### PR TITLE
Fix bug in the ty_trans_int_z diagnostic

### DIFF
--- a/src/mom5/ocean_diag/ocean_adv_vel_diag.F90
+++ b/src/mom5/ocean_diag/ocean_adv_vel_diag.F90
@@ -855,6 +855,7 @@ subroutine transport_on_s(Time, Adv_vel)
   endif 
  
   if (id_ty_trans > 0 .or. id_ty_trans_int_z > 0) then 
+    wrk1_2d(:,:) = 0.0
     do k=1,nk
       do j=jsc,jec
          do i=isc,iec


### PR DESCRIPTION
Previously, the temporary array `wrk1_2d(:,:)` was not correctly initialized
to zero within the `if (id_ty_trans_int_z)` statement block. This commit adds 
the correct initialization.

Previously, in the case where both `ty_trans_int_z` and either/or of `tx_trans` 
or `tx_trans_int_z` were active then the lack of initialization meant that the 
`ty_trans_int_z` diagnostic actually included the sum of `ty_trans_int_z` and 
`tx_trans_int_z`.

`tx_trans` and `ty_trans` were not affected.