### PR TITLE
Fixed restart_interval for all affected drivers

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,7 @@
 
 Where to start
 ~~~~~~~~~~~~~~
+
 A good place to start is the "doc" directory, where you
 will find  "user" guides for the MOM.
 

--- a/README
+++ b/README
@@ -1,7 +1,6 @@
 
 Where to start
 ~~~~~~~~~~~~~~
-
 A good place to start is the "doc" directory, where you
 will find  "user" guides for the MOM.
 

--- a/src/accesscm_coupler/ocean_solo.F90
+++ b/src/accesscm_coupler/ocean_solo.F90
@@ -275,7 +275,7 @@ program main
       read(unit,*) date_restart
       call mpp_close(unit)
   else
-      date_restart = date_init
+      date_restart = date
   endif
       
   call set_calendar_type (calendar_type)

--- a/src/accessom_coupler/ocean_solo.F90
+++ b/src/accessom_coupler/ocean_solo.F90
@@ -270,7 +270,7 @@ program main
       read(unit,*) date_restart
       call mpp_close(unit)
   else
-      date_restart = date_init
+      date_restart = date
   endif
 
   call set_calendar_type (calendar_type)

--- a/src/mom5/drivers/ocean_solo.F90
+++ b/src/mom5/drivers/ocean_solo.F90
@@ -242,7 +242,7 @@ ierr = check_nml_error(io_status,'ocean_solo_nml')
       read(unit,*) date_restart
       call mpp_close(unit)
   else
-      date_restart = date_init
+      date_restart = date
   endif
       
   call set_calendar_type (calendar_type)

--- a/src/mom5/drivers/ocean_solo_nuopc.inc
+++ b/src/mom5/drivers/ocean_solo_nuopc.inc
@@ -443,7 +443,7 @@ module ocean_solo_mod
         read(unit,*) date_restart
         call mpp_close(unit)
     else
-        date_restart = date_init
+        date_restart = date
     endif
         
     call set_calendar_type (calendar_type)


### PR DESCRIPTION
Closes #340 

Make `date_restart` equal the current model date if not explicitly set in `ocean_solo.intermediate.res`.

Fixes bug in all drivers but the default GFDL coupled driver, which has the correct code.