### PR TITLE
Fix the build of affinity.c on newer glibc

### DIFF
--- a/src/shared/mpp/affinity.c
+++ b/src/shared/mpp/affinity.c
@@ -7,12 +7,16 @@
 #include <sched.h>
 #include <errno.h>
 #include <sys/resource.h>
-#include <sys/syscall.h>
 
-static pid_t gettid(void)
-{
-  return syscall(__NR_gettid);
-}
+#if !defined(_GNU_SOURCE) || !defined(__GLIBC__) || __GLIBC__ < 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ < 30)
+#include <sys/syscall.h>
+static
+pid_t gettid ( void )
+ {
+   return syscall(__NR_gettid);
+ }
+#endif
+
 
 /*
  * Returns this thread's CPU affinity, if bound to a single core,


### PR DESCRIPTION
Hello,

I am trying to build the project on Ubuntu 20.04.2 ARM64.

Running ` ./MOM_compile.csh --platform ubuntu --type MOM_solo` fails with several errors, one of which is:

```
/home/ubuntu/git/2021.H2/MOM5/src/shared/mpp/affinity.c:12:14: error: static declaration of ‘gettid’ follows non-static declaration
   12 | static pid_t gettid(void)
      |              ^~~~~~
In file included from /usr/include/unistd.h:1170,
                 from /home/ubuntu/git/2021.H2/MOM5/src/shared/mpp/affinity.c:6:
/usr/include/aarch64-linux-gnu/bits/unistd_ext.h:34:16: note: previous declaration of ‘gettid’ was here
   34 | extern __pid_t gettid (void) __THROW;
      |                ^~~~~~
make: *** [Makefile:17: affinity.o] Error 1

```

I've borrowed the solution from https://github.com/ncbi/ncbi-vdb/issues/21#issuecomment-549140609