### PR TITLE
Set default date in access-om driver

### DIFF
--- a/src/accessom_coupler/ocean_solo.F90
+++ b/src/accessom_coupler/ocean_solo.F90
@@ -248,6 +248,8 @@ program main
 
   ! Use accessom2 configuration to initial date and runtime
   date_init(:) = accessom2%get_cur_exp_date_array()
+  ! Set default run date to initial date
+  date(:) = date_init(:)
   dt_cpld = accessom2%get_ice_ocean_timestep()
   years = 0
   months = 0


### PR DESCRIPTION
Closes #340 

The original fix for #340 introduced an error for the ACCESS-OM driver due to the way the driver initialises the date.

This is a pretty hacky fix, all the logic for setting the dates is very convoluted, and state dependent, but I don't want to change too much in case it breaks something.