### PR TITLE
Issue 353 fix

### DIFF
--- a/src/accesscm_coupler/ocean_solo.F90
+++ b/src/accesscm_coupler/ocean_solo.F90
@@ -268,6 +268,8 @@ program main
       read(unit,*) date_init
       read(unit,*) date
       call mpp_close(unit)
+  else
+      date = date_init
   endif
 
   if (file_exist('INPUT/ocean_solo.intermediate.res')) then

--- a/src/mom5/drivers/ocean_solo_nuopc.inc
+++ b/src/mom5/drivers/ocean_solo_nuopc.inc
@@ -436,6 +436,8 @@ module ocean_solo_mod
         read(unit,*) date_init
         read(unit,*) date
         call mpp_close(unit)
+    else
+      date_restart = date
     endif
 
     if (file_exist('INPUT/ocean_solo.intermediate.res')) then


### PR DESCRIPTION
Closes #353 

Adds the same cold start fix to accesscm ocean_solo and nuopc ocean_solo driver. The main coupler driver has more complex date/time management which I don't want to monkey with. It at least *seems* to be setting an initial date correctly, leaving that one.