### PR TITLE
Sw flux outputs

### DIFF
--- a/src/mom5/ocean_core/ocean_sbc.F90
+++ b/src/mom5/ocean_core/ocean_sbc.F90
@@ -1927,12 +1927,12 @@ subroutine ocean_sbc_diag_init(Time, Dens, T_prog)
 
   id_swflx = register_diag_field('ocean_model','swflx', Grd%tracer_axes(1:2),  &
        Time%model_time, 'shortwave flux into ocean (>0 heats ocean)', 'W/m^2', &
-       missing_value=missing_value,range=(/-1.e10,1.e10/),                     &
+       missing_value=4*missing_value,range=(/-1.e10,1.e10/),                     &
        standard_name='surface_net_downward_shortwave_flux')   
 
   id_swflx_vis = register_diag_field('ocean_model','swflx_vis', Grd%tracer_axes(1:2),&
        Time%model_time, 'visible shortwave into ocean (>0 heats ocean)', 'W/m^2' ,   &
-       missing_value=missing_value,range=(/-1.e10,1.e10/))   
+       missing_value=2*missing_value,range=(/-1.e10,1.e10/))   
 
   id_sw_flux_vis_dir = register_diag_field('ocean_model','sw_flux_vis_dir', Grd%tracer_axes(1:2),&
       Time%model_time, 'direct visible shortwave radiation [W m-2] (>0 heats ocean)', 'W/m^2' ,  &

--- a/src/mom5/ocean_core/ocean_sbc.F90
+++ b/src/mom5/ocean_core/ocean_sbc.F90
@@ -5646,10 +5646,10 @@ subroutine ocean_sbc_diag(Time, Velocity, Thickness, Dens, T_prog, Ice_ocean_bou
   call diagnose_2d(Time, Grd, id_swflx, swflx(:,:))
 
   ! visible and near-infrared components of shortwave radiation (direct and diffuse)
-  call diagnose_2d(Time, Grd, id_sw_flux_vis_dif, sw_flux_vis_dif(:,:))
-  call diagnose_2d(Time, Grd, id_sw_flux_vis_dir, sw_flux_vis_dir(:,:))
-  call diagnose_2d(Time, Grd, id_sw_flux_nir_dif, sw_flux_nir_dif(:,:))
-  call diagnose_2d(Time, Grd, id_sw_flux_nir_dir, sw_flux_nir_dir(:,:))
+  call diagnose_2d(Time, Grd, id_sw_flux_vis_dif, Ice_ocean_boundary%sw_flux_vis_dif(:,:))
+  call diagnose_2d(Time, Grd, id_sw_flux_vis_dir, Ice_ocean_boundary%sw_flux_vis_dir(:,:))
+  call diagnose_2d(Time, Grd, id_sw_flux_nir_dif, Ice_ocean_boundary%sw_flux_nir_dif(:,:))
+  call diagnose_2d(Time, Grd, id_sw_flux_nir_dir, Ice_ocean_boundary%sw_flux_nir_dir(:,:))
 
   ! total shortwave heat transport (Watts)
   call diagnose_sum(Time, Grd, Dom, id_total_ocean_swflx, swflx, 1e-15)

--- a/src/mom5/ocean_core/ocean_sbc.F90
+++ b/src/mom5/ocean_core/ocean_sbc.F90
@@ -1731,7 +1731,7 @@ subroutine ocean_sbc_diag_init(Time, Dens, T_prog)
 
   id_u10 = register_diag_field('ocean_model','u10', Grd%tracer_axes(1:2),&
        Time%model_time, 'Wind speed', 'm/s',                   &
-       missing_value=missing_value,range=(/-10.,10./),                       &
+       missing_value=missing_value,range=(/-100.,100./),                       &
        standard_name='Magntiude of wind velocity')
 
   id_wavlen = register_diag_field('ocean_model','ww3 wavlen', Grd%tracer_axes(1:2),  &
@@ -5646,10 +5646,10 @@ subroutine ocean_sbc_diag(Time, Velocity, Thickness, Dens, T_prog, Ice_ocean_bou
   call diagnose_2d(Time, Grd, id_swflx, swflx(:,:))
 
   ! visible and near-infrared components of shortwave radiation (direct and diffuse)
-  call diagnose_2d(Time, Grd, id_sw_flux_vis_dif,  sw_flux_vis_dif(:,:))
-  call diagnose_2d(Time, Grd, id_sw_flux_vis_dir,  sw_flux_vis_dir(:,:))
-  call diagnose_2d(Time, Grd, id_sw_flux_nir_dif,  sw_flux_nir_dif(:,:))
-  call diagnose_2d(Time, Grd, id_sw_flux_nir_dir,  sw_flux_nir_dir(:,:))
+  call diagnose_2d(Time, Grd, id_sw_flux_vis_dif, sw_flux_vis_dif(:,:))
+  call diagnose_2d(Time, Grd, id_sw_flux_vis_dir, sw_flux_vis_dir(:,:))
+  call diagnose_2d(Time, Grd, id_sw_flux_nir_dif, sw_flux_nir_dif(:,:))
+  call diagnose_2d(Time, Grd, id_sw_flux_nir_dir, sw_flux_nir_dir(:,:))
 
   ! total shortwave heat transport (Watts)
   call diagnose_sum(Time, Grd, Dom, id_total_ocean_swflx, swflx, 1e-15)


### PR DESCRIPTION
1. Diagnostics are added for four types of shortwave components.
2. Missing values of swflx and sw_flux_vis are changed to 4 and 2 times the hardcoded missing values (=-1.e+20).