### PR TITLE
Corrected documentation for u_surf and v_surf

### DIFF
--- a/src/coupler/flux_exchange.F90
+++ b/src/coupler/flux_exchange.F90
@@ -2934,7 +2934,7 @@ subroutine flux_ice_to_ocean ( Time, Ice, Ocean, Ice_Ocean_Boundary )
 !        t_surf = surface temperature (deg K)
 !        frazil = frazil (???)
 !        u_surf = zonal ocean current/ice motion (m/s)
-!        v_surf = meridional ocean current/ice motion (m/s
+!        v_surf = meridional ocean current/ice motion (m/s)
 !  </PRE>
 !  </DESCRIPTION>
 !  <TEMPLATE>

--- a/src/coupler/surface_flux.F90
+++ b/src/coupler/surface_flux.F90
@@ -87,10 +87,10 @@ public  surface_flux
 !  Mixing ratio at earth surface (kg/kg). 
 !  </OUT>
 !  <IN NAME="u_surf" TYPE="real, dimension(:)" UNITS="m/s">
-!  Zonal wind velocity at earth surface.   
+!  Absolute zonal velocity of ocean/ice at the earth surface.
 !  </IN>
 !  <IN NAME="v_surf" TYPE="real, dimension(:)" UNITS="m/s">
-!  Meridional wind velocity at earth surface. 
+!  Absolute meridional velocity of ocean/ice at the earth surface.
 !  </IN>
 !  <IN NAME="rough_mom" TYPE="real, dimension(:)" UNITS="m">
 !  Momentum roughness length

--- a/src/coupler/surface_flux.F90
+++ b/src/coupler/surface_flux.F90
@@ -87,10 +87,10 @@ public  surface_flux
 !  Mixing ratio at earth surface (kg/kg). 
 !  </OUT>
 !  <IN NAME="u_surf" TYPE="real, dimension(:)" UNITS="m/s">
-!  Absolute zonal velocity of ocean/ice at the earth surface.
+!  Zonal ocean current/ice motion at earth surface.
 !  </IN>
 !  <IN NAME="v_surf" TYPE="real, dimension(:)" UNITS="m/s">
-!  Absolute meridional velocity of ocean/ice at the earth surface.
+!  Meridional ocean current/ice motion at earth surface.
 !  </IN>
 !  <IN NAME="rough_mom" TYPE="real, dimension(:)" UNITS="m">
 !  Momentum roughness length


### PR DESCRIPTION
u_surf and v_surf is the ocean current or ice motion at the earth's surface. This PR changes two files:
1. src/coupler/flux_exchange.F90
2. src/coupler/surface_flux.F90