### PR TITLE
Fix CMake build for use with spack

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -75,6 +75,8 @@ elseif(CMAKE_C_COMPILER_ID STREQUAL "GNU")
 else ()
   message ("Unknown C compiler default flags only...")
 endif()
+execute_process(COMMAND nc-config --cflags OUTPUT_VARIABLE NETCDF_CFLAGS OUTPUT_STRIP_TRAILING_WHITESPACE)
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${NETCDF_CFLAGS}")
 
 # Transfer command line setting of CPP defs to CMake 
 set(CPPDEFS 


### PR DESCRIPTION
Current CMake build doesn't play nicely with spack.

This PR is making a spack package

https://github.com/ACCESS-NRI/spack_packages/pull/3

but MOM5 doesn't build correctly, so some modifications are required to the CMake build.