### PR TITLE
MOM5 updates from ACCESS-ESM1.5

### DIFF
--- a/bin/environs.nci
+++ b/bin/environs.nci
@@ -4,3 +4,4 @@ module load intel-compiler/2019.5.281
 module load netcdf/4.7.4
 module load openmpi/4.0.2
 setenv mpirunCommand   "mpirun --mca orte_base_help_aggregate 0 -np"
+setenv OASIS_ROOT /g/data/p66/pbd562/test/t47-hxw/jan20/4.0.2/oasis3-mct

--- a/exp/compile_esm.sh
+++ b/exp/compile_esm.sh
@@ -1,0 +1,2 @@
+./MOM_compile.csh --platform=nci --type=ACCESS-ESM
+

--- a/src/mom5/ocean_csiro_bgc/bio_v3.inc
+++ b/src/mom5/ocean_csiro_bgc/bio_v3.inc
@@ -40,6 +40,7 @@ integer :: index_temp, index_salt
 
       integer :: ts_npzd ! number of time steps within NPZD model
       integer :: kmeuph = 20 ! deepest level of  euphotic zone
+      integer :: k100 = 10 ! deepest level less than 100 m
       integer :: tn, trn
 
       real :: pi    = 3.14159265358979  !yes, this is pi
@@ -96,8 +97,10 @@ integer :: index_temp, index_salt
 ! set the maximum index for euphotic depth
       do k=1,grid%nk
          if (grid%zw(k).le. 400) kmeuph=k
+         if (grid%zw(k).le. 100) k100=k
       enddo
 !        print*,'rjm euphotic ', kmeuph
+!        print*,'mac k100 ', k100
 
 !
 !
@@ -140,6 +143,8 @@ do n = 1, instances  !{
 
   pprod_gross(:,:,:) = 0.0
   zprod_gross(:,:,:) = 0.0
+  export_prod(:,:) = 0.0
+  export_inorg(:,:) = 0.0
   light_limit(:,:) = 0.0
   radbio3d(:,:,:) = 0.0
   npp3d(:,:,:) = 0.0
@@ -169,7 +174,8 @@ do n = 1, instances  !{
   ind_dic = biotic(n)%ind_bgc(id_dic)
   ind_adic = biotic(n)%ind_bgc(id_adic)
   ind_alk = biotic(n)%ind_bgc(id_alk)
-  ind_po4 = biotic(n)%ind_bgc(id_po4)
+!  ind_po4 = biotic(n)%ind_bgc(id_po4)
+  if (id_po4 .ne. 0) ind_po4 = biotic(n)%ind_bgc(id_po4)
   ind_o2  = biotic(n)%ind_bgc(id_o2)
 
   ind_no3  = biotic(n)%ind_bgc(id_no3)
@@ -328,7 +334,7 @@ do n = 1, instances  !{
 ! change the ratio of remineralisation of det in upper to lower ocean from 5 to 2,
 !  but keep the remin rate the same at depth, so change the value in rjm_param_2010.... as well
 !  mac, jun10.
-        if (grid%zw(k) .ge. 180) f41 = f41*.5   ! reduce decay below 300m
+        if (grid%zw(k) .ge. 180) f41 = f41*.5   ! reduce decay at depth
 
         if (id_caco3.ne.0) then 
           f51 = muecaco3(i,j)*biocaco3 *bioma(i,k,id_caco3)
@@ -381,6 +387,14 @@ do n = 1, instances  !{
          enddo  !} i
         enddo  !} k
        enddo  !} tn 
+
+
+! Calculate export production, organic and inorganic.  mac, sep18.  
+        k=k100
+        do i = isc, iec  !{
+         export_prod(i,j)=t_prog(ind_det)%field(i,j,k,time%taum1)*wdetbio(i,j)*grid%tmask(i,j,k)
+         export_inorg(i,j)=t_prog(ind_caco3)%field(i,j,k,time%taum1)*wcaco3(i,j)*grid%tmask(i,j,k)
+        enddo  !} i
 
 
 !chd  add biotically induced tendency to biotracers,

--- a/src/mom5/ocean_csiro_bgc/csiro_bgc.F90
+++ b/src/mom5/ocean_csiro_bgc/csiro_bgc.F90
@@ -1006,9 +1006,10 @@ if (gasx_from_file) then
 else
  do j=jsc, jec
   do i=isc, iec
-! the relations 0.31 * u^2 comes from Wanninkhof 1992, and is the coefficient for steady wind speed; the equation is 0.39 * u^2 for instaneous wind speeds. I don't know what exactly the timescale is between steady and instaneous...
+i! the relations 0.31 * u^2 comes from Wanninkhof 1992, and is the coefficient for steady wind speeds, suitable for shipboard spot
+! measurements or derived from scatterometers; the equation is 0.39 * u^2 for long-term wind speeds (e.g. climatology). 
 ! the 3.6e5 is a conversion of units; cm/hr to m/s.
-! mac, may13.
+! mac, may13 (comments updated feb22).
    xkw_t(i,j)=(0.31 * wnd(i,j)**2.0 ) /3.6e5   
   enddo ! i
  enddo ! j

--- a/src/mom5/ocean_csiro_bgc/csiro_bgc.F90
+++ b/src/mom5/ocean_csiro_bgc/csiro_bgc.F90
@@ -1006,7 +1006,7 @@ if (gasx_from_file) then
 else
  do j=jsc, jec
   do i=isc, iec
-i! the relations 0.31 * u^2 comes from Wanninkhof 1992, and is the coefficient for steady wind speeds, suitable for shipboard spot
+! the relations 0.31 * u^2 comes from Wanninkhof 1992, and is the coefficient for steady wind speeds, suitable for shipboard spot
 ! measurements or derived from scatterometers; the equation is 0.39 * u^2 for long-term wind speeds (e.g. climatology). 
 ! the 3.6e5 is a conversion of units; cm/hr to m/s.
 ! mac, may13 (comments updated feb22).


### PR DESCRIPTION
Some minor changes were required to the MOM5 source code in order to run with ACCESS-ESM1.5. 
There are also some updated diagnostics and commentary in the ocean BGC.  
None of these affect the normal running of the model. 
These changes compiled and tested OK with ESM1.5 on gadi.

In particular:
-    setenv OASIS_ROOT is added in environs.nci.
-    put 'sea ice to ocean' exchanges of nutrients and algae within a "sea_ice_bgc'-flagged block (sea ice BGC not defined in ESM and crashes model).
-    extra diagnostics are added for organic + inorganic export, and surface hydrogen ion concentration. 
-    limit the 'Schmidt temperature' in surface gas exchange (was required for hot ESM experiments).

Cheers, Matt. 