### PR TITLE
Default to not including git hash in build for non ACCESS-OM2 models

### DIFF
--- a/exp/MOM_compile.csh
+++ b/exp/MOM_compile.csh
@@ -151,6 +151,7 @@ if ( $cosima_version ) then
     echo "Including COSIMA version in build"
     # Build version. This prevents builds outside a git repo, so only enabled for COSIMA builds
     source ./version_compile.csh
+    set cppDefs = "$cppDefs -DCOSIMA_VERSION"
 endif
 
 # Build FMS.

--- a/exp/MOM_compile.csh
+++ b/exp/MOM_compile.csh
@@ -94,7 +94,7 @@ endif
 
 if( $cosima_version == "unset" ) then
     if( $type =~ ACCESS-OM* ) then
-        # default to cosima versioniing for ACCESS-OM if not set explicitly as no_version argument
+        # default to cosima versioning for ACCESS-OM if not set explicitly as no_version argument
         set cosima_version = 1
     else
         set cosima_version = 0

--- a/exp/MOM_compile.csh
+++ b/exp/MOM_compile.csh
@@ -10,9 +10,10 @@ set debug = 0
 set repro = 0
 set use_netcdf4 = 0
 set environ = 1
+set cosima_version = unset
 
 
-set argv = (`getopt -u -o h -l type: -l platform: -l help -l unit_testing -l debug -l repro -l use_netcdf4 -l no_environ --  $*`)
+set argv = (`getopt -u -o h -l type: -l platform: -l help -l unit_testing -l debug -l repro -l use_netcdf4 -l no_environ -l no_version --  $*`)
 if ($status != 0) then
   # Die if there are incorrect options
   set help = 1
@@ -34,6 +35,8 @@ while ("$argv[1]" != "--")
                 set use_netcdf4 = 1; breaksw
         case --no_environ:
                 set environ = 0; breaksw
+        case --no_version:
+                set cosima_version = 0; breaksw
         case --help:
                 set help = 1;  breaksw
         case -h:
@@ -63,7 +66,9 @@ if ( $help ) then
     echo
     echo "--use_netcdf4  use NetCDF4, the default is NetCDF4. Warning: many of the standard experiments don't work with NetCDF4."
     echo
-    echo "--no_environ  do not source platform specific environment. Allows customising/overriding default environment"
+    echo "--no_environ do not source platform specific environment. Allows customising/overriding default environment"
+    echo
+    echo "--no_version disable COSIMA specific versioning for ACCESS-OM* builds"
     echo
     exit 1
 endif
@@ -85,6 +90,15 @@ set static        = 0              # 1 if you want static memory allocation, 0 f
 if($static) then
   set executable = $root/exec/$platform/${type}_static/fms_$type.x
   set cppDefs = "$cppDefs -DMOM_STATIC_ARRAYS -DNI_=360 -DNJ_=200 -DNK_=50 -DNI_LOCAL_=60 -DNJ_LOCAL_=50"
+endif
+
+if( $cosima_version == "unset" ) then
+    if( $type =~ ACCESS-OM* ) then
+        # default to cosima versioniing for ACCESS-OM if not set explicitly as no_version argument
+        set cosima_version = 1
+    else
+        set cosima_version = 0
+    endif
 endif
 
 if ( $type == EBM ) then
@@ -133,13 +147,20 @@ endif
 set mkmf_lib = "$mkmf -f -m Makefile -a $code_dir -t $mkmfTemplate"
 set lib_include_dirs = "$root/include $code_dir/shared/include $code_dir/shared/mpp/include"
 
-# Build version
-source ./version_compile.csh
+if ( $cosima_version ) then
+    echo "Including COSIMA version in build"
+    # Build version. This prevents builds outside a git repo, so only enabled for COSIMA builds
+    source ./version_compile.csh
+endif
 
 # Build FMS.
 source ./FMS_compile.csh
 
-set includes = "-I$code_dir/shared/include -I$executable:h:h/lib_FMS -I$executable:h:h/lib_ocean -I$executable:h:h/lib_version/"
+set includes = "-I$code_dir/shared/include -I$executable:h:h/lib_FMS -I$executable:h:h/lib_ocean"
+
+if ( $cosima_version ) then
+    set includes = "$includes -I$executable:h:h/lib_version/"
+endif
 
 # Build the core ocean.
 cd $root/exp
@@ -232,8 +253,12 @@ else
     exit 1
 endif
 
-# Always include FMS and version
-set libs = "$libs $executable:h:h/lib_version/lib_version.a $executable:h:h/lib_FMS/lib_FMS.a"
+# Always include FMS
+set libs = "$libs $executable:h:h/lib_FMS/lib_FMS.a"
+
+if ( $cosima_version ) then
+    set libs = "$libs $executable:h:h/lib_version/lib_version.a"
+endif
 
 $mkmf_exec -o "$includes" -c "$cppDefs" -l "$libs"  $srcList
 make

--- a/src/mom5/ocean_core/ocean_model.F90
+++ b/src/mom5/ocean_core/ocean_model.F90
@@ -334,7 +334,9 @@ use ocean_xlandmix_mod,           only: ocean_xlandmix_init, xlandmix
 use ocean_drifters_mod,           only: ocean_drifters_init, update_ocean_drifters, ocean_drifters_end
 use wave_types_mod,               only: ocean_wave_type
 use ocean_wave_mod,               only: ocean_wave_init, ocean_wave_end, ocean_wave_model
-use version_mod,                  only: MOM_COMMIT_HASH
+#if defined(COSIMA_VERSION)
+  use version_mod,                  only: MOM_COMMIT_HASH
+#endif
 
 #if defined(ACCESS_CM) || defined(ACCESS_OM)
   use auscom_ice_mod, only: auscom_ice_init

--- a/src/mom5/ocean_core/ocean_model.F90
+++ b/src/mom5/ocean_core/ocean_model.F90
@@ -698,9 +698,11 @@ subroutine ocean_model_init(Ocean, Ocean_state, Time_init, Time_in, &
     stdoutunit=stdout()
     stdlogunit=stdlog() 
 
+#ifdef COSIMA_VERSION
     if (mpp_pe() == mpp_root_pe()) then
         write(stdoutunit,*) MOM_COMMIT_HASH
     endif
+#endif
 
     if (module_is_initialized) then 
       call mpp_error(FATAL, &


### PR DESCRIPTION
Removed adding a version hash to every build with the exception of ACCESS-OM* models. 

Added `--no_version` option to also not include version hash in ACCESS-OM builds.

This is necessary because it prevents all of the model types from building outside of a `git` repository (see #308).

Being able to build from a tarball is desirable for a number of reasons:

1. The code is available as tarballs directly from GitHub
2. Tarballs are the standard way of release code in packages on GitHub
3. [spack](spack.io) needs to be able to access code as a tarball from GitHub to enable building specific versions (https://github.com/ACCESS-NRI/spack_packages/issues/32), and spack has it's own versioning

Closes #308 