### PR TITLE
Pass salt flux restoring/correction to generic tracers

### DIFF
--- a/src/mom5/ocean_core/ocean_model.F90
+++ b/src/mom5/ocean_core/ocean_model.F90
@@ -1605,7 +1605,7 @@ subroutine ocean_model_init(Ocean, Ocean_state, Time_init, Time_in, &
        ! compute "flux adjustments" (e.g., surface tracer restoring, flux correction)
        call mpp_clock_begin(id_flux_adjust)
        call flux_adjust(Time, T_diag(1:num_diag_tracers), Dens, Ext_mode, &
-                        T_prog(1:num_prog_tracers), Velocity, river, melt, pme)
+                        T_prog(1:num_prog_tracers), Velocity, river, melt, pme, runoff)
 
        call mpp_clock_end(id_flux_adjust)
 

--- a/src/mom5/ocean_tracers/ocean_tpm.F90
+++ b/src/mom5/ocean_tracers/ocean_tpm.F90
@@ -46,6 +46,10 @@ module ocean_tpm_mod  !{
 !               this functionality may be moved into a new, generalized
 !               boundary condition manager.
 !
+!       ocean_tpm_sbc_adjust: Calls specified routines to adjust
+!               surface boundary condition, e.g. due to virtual fluxes
+!               that arise from salinity restoring
+!
 !       ocean_tpm_bbc: Calls specified routines to handle bottom
 !               coundary condition calculations.
 !
@@ -221,6 +225,7 @@ use ocean_generic_mod, only: do_generic_tracer
 use ocean_generic_mod, only: ocean_generic_sum_sfc
 use ocean_generic_mod, only: ocean_generic_zero_sfc
 use ocean_generic_mod, only: ocean_generic_sbc
+use ocean_generic_mod, only: ocean_generic_sbc_adjust
 use ocean_generic_mod, only: ocean_generic_init
 use ocean_generic_mod, only: ocean_generic_column_physics
 use ocean_generic_mod, only: ocean_generic_end
@@ -267,6 +272,7 @@ public ocean_tpm_end
 public ocean_tpm_init
 public ocean_tpm_flux_init
 public ocean_tpm_sbc
+public ocean_tpm_sbc_adjust
 public ocean_tpm_source
 public ocean_tpm_start
 public ocean_tpm_tracer
@@ -1336,6 +1342,54 @@ return
 end subroutine ocean_tpm_sbc  !}
 ! </SUBROUTINE> NAME="ocean_tpm_sbc"
 
+!#######################################################################
+! <SUBROUTINE NAME="ocean_tpm_sbc_adjust">
+!
+! <DESCRIPTION>
+!       call subroutines to adjust surface boundary condition, e.g. due to
+!       virtual fluxes that arise from salinity restoring
+! </DESCRIPTION>
+!
+
+subroutine ocean_tpm_sbc_adjust(Domain, T_prog, salt_flux_added, runoff)
+
+
+implicit none
+
+!
+!-----------------------------------------------------------------------
+!       Arguments
+!-----------------------------------------------------------------------
+!
+
+type(ocean_domain_type), intent(in)                             :: Domain
+type(ocean_prog_tracer_type), dimension(:), intent(inout)       :: T_prog
+real, dimension(Domain%isd:,Domain%jsd:), intent(in)            :: salt_flux_added
+real, dimension(Domain%isd:,Domain%jsd:), intent(in)            :: runoff
+
+!
+!-----------------------------------------------------------------------
+!     local parameters
+!-----------------------------------------------------------------------
+!
+
+!
+!-----------------------------------------------------------------------
+!     local variables
+!-----------------------------------------------------------------------
+!
+
+
+#ifdef USE_OCEAN_BGC
+
+if (do_generic_tracer) call ocean_generic_sbc_adjust(Domain%isd, Domain%jsd, T_prog, salt_flux_added, runoff)
+
+#endif
+
+return
+
+end subroutine ocean_tpm_sbc_adjust  !}
+! </SUBROUTINE> NAME="ocean_tpm_sbc_adjust"
 
 !#######################################################################
 ! <SUBROUTINE NAME="ocean_tpm_init">


### PR DESCRIPTION
See #389 for context and details. 

Reiterating from that issue:
These changes should not alter the current behaviour of MOM5 if the `generic_tracer` code in the local `ocean_shared` directory is used. However, if an external `generic_tracer` codebase is used (e.g. [NOAA-GFDL/ocean_BGC](https://github.com/NOAA-GFDL/ocean_BGC/tree/master)), that code will need to include the new `generic_tracer::generic_tracer_update_from_coupler` routine. There is currently [an open PR to add this routine to NOAA-GFDL/ocean_BGC](https://github.com/NOAA-GFDL/ocean_BGC/pull/35).

Closes #389 