### PR TITLE
Update to latest FMS version

### DIFF
--- a/src/shared/.github/workflows/CI.yml
+++ b/src/shared/.github/workflows/CI.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-18.04, ubuntu-20.04 ] 
+        os: [ ubuntu-20.04 ] 
         # gcc_v: [8, 9] # Version of GFortran we want to use.
         build: [ Release, Debug ]
     runs-on: ${{ matrix.os }}

--- a/src/shared/.gitrepo
+++ b/src/shared/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = git@github.com:mom-ocean/FMS.git
 	branch = master
-	commit = 3bd24800ed3cd8b0eb26643afdecf88e10641beb
-	parent = 80ece3dfb05c11db1a526930d0eff9a395405f13
+	commit = 98a5532b2e261e408ed0f32e0738fc601bd96594
+	parent = 59e0aad14896027d4c11a936b936a0325e77dbcf
 	method = merge
-	cmdver = 0.4.0
+	cmdver = 0.4.9


### PR DESCRIPTION
Update to latest FMS version from fork via subrepo

Closes #393 

```
git subrepo clone (merge) --force git@github.com:mom-ocean/FMS.git src/shared

subrepo:
  subdir:   "src/shared"
  merged:   "98a5532b"
upstream:
  origin:   "git@github.com:mom-ocean/FMS.git"
  branch:   "master"
  commit:   "98a5532b"
git-subrepo:
  version:  "0.4.9"
  origin:   "https://github.com/ingydotnet/git-subrepo"
  commit:   "57de7d6"
```